### PR TITLE
DISTMYSQL-140: Create dev Jenkins pipeline for Orchestrator

### DIFF
--- a/docker/Dockerfile.system
+++ b/docker/Dockerfile.system
@@ -1,13 +1,33 @@
 FROM golang:1.16.6-stretch
 LABEL maintainer="openark@github.com"
 
+ARG ci_env_repo="https://github.com/percona/orchestrator-ci-env.git"
+ARG ci_env_branch=master
+
+RUN echo "ci_env_repo: $ci_env_repo"
+RUN echo "ci_env_branch: $ci_env_branch"
+
 RUN apt-get update -q -y
 RUN apt-get install -y sudo haproxy python git jq rsync libaio1 libnuma1 mysql-client bsdmainutils less vim
 
 RUN mkdir /orchestrator
 WORKDIR /orchestrator
 
-RUN git clone https://github.com/openark/orchestrator-ci-env.git # cache
+RUN git clone -b $ci_env_branch $ci_env_repo # cache
+# For dev purposes only, just to avoid cloning over and over
+# COPY docker/orchestrator-ci-env /orchestrator/orchestrator-ci-env
+
+# Setup dbdeployer
+RUN mkdir /dbdeployer
+RUN (cd /dbdeployer && wget https://github.com/datacharmer/dbdeployer/releases/download/v1.64.0/dbdeployer-1.64.0.linux.tar.gz)
+RUN (cd /dbdeployer && tar -xf dbdeployer-1.64.0.linux.tar.gz)
+RUN (cd /dbdeployer && ln -s dbdeployer-1.64.0.linux dbdeployer)
+RUN (cd /dbdeployer && ./dbdeployer defaults update reserved-ports '0')
+RUN (cd /orchestrator/orchestrator-ci-env/bin/linux && ln -s /dbdeployer/dbdeployer)
+
+# For dev purposes only, just to avoid downloading over and over via download-mysql script
+# RUN (mkdir /orchestrator/orchestrator-ci-env/mysql-tarballs-downloaded)
+# COPY docker/Percona-Server-8.0.26-16-Linux.x86_64.glibc2.12-minimal.tar.gz /orchestrator/orchestrator-ci-env/mysql-tarballs-downloaded/ 
 
 RUN (cd /orchestrator/orchestrator-ci-env && cp bin/linux/systemctl.py /usr/bin/systemctl)
 RUN (cd /orchestrator/orchestrator-ci-env && script/deploy-haproxy)
@@ -19,4 +39,4 @@ WORKDIR /orchestrator
 COPY . .
 RUN (cd /orchestrator && script/build)
 
-CMD (cd /orchestrator/orchestrator-ci-env && script/docker-entry && cd /orchestrator && docker/docker-entry-system && /bin/bash)
+CMD (cd /orchestrator/orchestrator-ci-env && script/docker-entry && cd /orchestrator && docker/docker-entry-system && docker/docker-entry-system-tests)

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -8,14 +8,19 @@ RUN rm -rf /var/lib/apt/lists/*
 ENV WORKPATH /go/src/github.com/openark/orchestrator
 WORKDIR $WORKPATH
 
-RUN curl -O "https://raw.githubusercontent.com/openark/orchestrator-ci-env/master/bin/linux/dbdeployer.gz"
-RUN curl -O "https://raw.githubusercontent.com/openark/orchestrator-ci-env/master/mysql-tarballs/mysql-5.7.26.tar.xz"
-RUN gunzip ./dbdeployer.gz
-RUN chmod +x ./dbdeployer
-RUN mkdir -p ./sandbox/binary
+# Setup dbdeployer
+RUN mkdir /dbdeployer
+RUN (cd /dbdeployer && wget https://github.com/datacharmer/dbdeployer/releases/download/v1.64.0/dbdeployer-1.64.0.linux.tar.gz)
+RUN (cd /dbdeployer && tar -xf dbdeployer-1.64.0.linux.tar.gz)
+RUN (cd /dbdeployer && ln -s dbdeployer-1.64.0.linux dbdeployer)
+RUN (cd /dbdeployer && ./dbdeployer defaults update reserved-ports '0')
 
-RUN ./dbdeployer unpack mysql-5.7.26.tar.xz --sandbox-binary $WORKPATH/sandbox/binary
+# For dev purposes only, just to avoid downloading over and over via download-mysql script
+# RUN (mkdir /mysql-tarballs-downloaded)
+# COPY docker/Percona-Server-8.0.26-16-Linux.x86_64.glibc2.12-minimal.tar.gz /mysql-tarballs-downloaded/ 
 
 COPY . .
+RUN (cd /dbdeployer && ./dbdeployer defaults update reserved-ports '0')
 
-CMD ["script/test-all"]
+ENV TARBAL_URL_DEFAULT https://raw.githubusercontent.com/kamil-holubicki/orchestrator-ci-env/master/mysql-tarballs/mysql-5.7.26.tar.xz
+CMD (cd $WORKPATH && "script/download-mysql" && "script/test-all")

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -22,5 +22,5 @@ RUN (cd /dbdeployer && ./dbdeployer defaults update reserved-ports '0')
 COPY . .
 RUN (cd /dbdeployer && ./dbdeployer defaults update reserved-ports '0')
 
-ENV TARBAL_URL_DEFAULT https://raw.githubusercontent.com/kamil-holubicki/orchestrator-ci-env/master/mysql-tarballs/mysql-5.7.26.tar.xz
+ENV TARBAL_URL_DEFAULT https://raw.githubusercontent.com/percona/orchestrator-ci-env/master/mysql-tarballs/mysql-5.7.26.tar.xz
 CMD (cd $WORKPATH && "script/download-mysql" && "script/test-all")

--- a/docker/docker-entry-system-tests
+++ b/docker/docker-entry-system-tests
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Make sure that we use binaries from the bundle we installed, not the system ones
+mysql_bin_dir=(~/opt/mysql/*/bin)
+PATH=$mysql_bin_dir:$PATH
+echo PATH: $PATH
+
+if [ "$RUN_TESTS" == "YES" ] ; then
+  echo "Automatic tests start requested"
+  script/test-system
+else
+  echo "Automatic tests start skipped"
+  /bin/bash
+fi

--- a/run/test-integration.sh
+++ b/run/test-integration.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+export TARBALL_URL=
+export RUN_TESTS=
+export ALLOW_TESTS_FAILURES=
+export CI_ENV_REPO=
+export CI_ENV_BRANCH=
+
+# Configure test run parameters
+export TARBALL_URL=https://downloads.percona.com/downloads/Percona-Server-8.0/Percona-Server-8.0.26-16/binary/tarball/Percona-Server-8.0.26-16-Linux.x86_64.glibc2.12-minimal.tar.gz
+export RUN_TESTS=YES
+export ALLOW_TESTS_FAILURES=YES
+
+script/dock test

--- a/run/test-system.sh
+++ b/run/test-system.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+export TARBALL_URL=
+export RUN_TESTS=
+export ALLOW_TESTS_FAILURES=
+export CI_ENV_REPO=
+export CI_ENV_BRANCH=
+
+# Configure test run parameters
+export TARBALL_URL=https://downloads.percona.com/downloads/Percona-Server-8.0/Percona-Server-8.0.26-16/binary/tarball/Percona-Server-8.0.26-16-Linux.x86_64.glibc2.12-minimal.tar.gz
+export RUN_TESTS=YES
+export ALLOW_TESTS_FAILURES=YES
+
+# It is also possible to specify custom ci-env
+#export CI_ENV_REPO=https://github.com/kamil-holubicki/orchestrator-ci-env.git
+#export CI_ENV_BRANCH=DISTMYSQL-140
+
+script/dock system

--- a/script/dock
+++ b/script/dock
@@ -9,12 +9,30 @@
 #   dock system:              create and run a system test environment
 #   dock raft:                build and run orchestrator in a 3-node raft setup
 
+
+if [[ -z ${CI_ENV_REPO} ]] ; then
+  CI_ENV_REPO_ENV=https://github.com/percona/orchestrator-ci-env.git
+else
+  CI_ENV_REPO_ENV=${CI_ENV_REPO}
+fi
+
+if [[ -z ${CI_ENV_BRANCH} ]] ; then
+  CI_ENV_BRANCH_ENV=master
+else
+  CI_ENV_BRANCH_ENV=${CI_ENV_BRANCH}
+fi
+
+
 command="$1"
 
 case "$command" in
   "test")
     docker_target="orchestrator-test"
-    docker build . -f docker/Dockerfile.test -t "${docker_target}" && docker run --rm -it "${docker_target}:latest"
+    docker build . -f docker/Dockerfile.test -t "${docker_target}" && docker run --rm -it --env TARBALL_URL=${TARBALL_URL} --env RUN_TESTS=${RUN_TESTS} --env ALLOW_TESTS_FAILURES=${ALLOW_TESTS_FAILURES} "${docker_target}:latest"
+    ;;
+  "test-no-it")
+    docker_target="orchestrator-test"
+    docker build . -f docker/Dockerfile.test -t "${docker_target}" && docker run --rm --env TARBALL_URL=${TARBALL_URL} --env RUN_TESTS=${RUN_TESTS} --env ALLOW_TESTS_FAILURES=${ALLOW_TESTS_FAILURES} "${docker_target}:latest"
     ;;
   "alpine")
     docker_target="orchestrator-alpine"
@@ -37,7 +55,11 @@ case "$command" in
     ;;
   "system")
     docker_target="orchestrator-system"
-    docker build . -f docker/Dockerfile.system -t "${docker_target}" && docker run --rm -it -p 3000:3000 "${docker_target}:latest"
+    docker build . -f docker/Dockerfile.system -t "${docker_target}" --build-arg ci_env_repo=${CI_ENV_REPO_ENV} --build-arg ci_env_branch=${CI_ENV_BRANCH_ENV} && docker run --rm -it -p 3000:3000 --env TARBALL_URL=${TARBALL_URL} --env RUN_TESTS=${RUN_TESTS} --env ALLOW_TESTS_FAILURES=${ALLOW_TESTS_FAILURES} "${docker_target}:latest" 
+    ;;
+  "system-no-it")
+    docker_target="orchestrator-system"
+    docker build . -f docker/Dockerfile.system -t "${docker_target}" --build-arg ci_env_repo=${CI_ENV_REPO_ENV} --build-arg ci_env_branch=${CI_ENV_BRANCH_ENV} && docker run --rm --env TARBALL_URL=${TARBALL_URL} --env RUN_TESTS=${RUN_TESTS} --env ALLOW_TESTS_FAILURES=${ALLOW_TESTS_FAILURES} "${docker_target}:latest" 
     ;;
   "raft")
     docker_target="orchestrator-raft"

--- a/script/download-mysql
+++ b/script/download-mysql
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Download PS tarball. Comment it out if direct copy is done in Dockerfile
+
+if [[ -z "${TARBALL_URL}" ]] ; then
+  echo Downloading custom tarball skipped. Will use default one.
+  if [[ -n "${TARBAL_URL_DEFAULT}" ]] ; then
+    echo Downloading default tarball.
+    mkdir /mysql-tarballs-downloaded
+    pushd /mysql-tarballs-downloaded
+    wget ${TARBAL_URL_DEFAULT}  
+    popd
+  fi
+else
+  mkdir /mysql-tarballs-downloaded
+  pushd /mysql-tarballs-downloaded
+  wget ${TARBALL_URL}  
+  popd
+fi

--- a/script/test-integration
+++ b/script/test-integration
@@ -4,10 +4,30 @@ export GOPATH="$PWD/.gopath"
 cd .gopath/src/github.com/openark/orchestrator
 
 setup_mysql() {
-  if [ ! -f "dbdeployer" ] ; then
+  if [ ! -f "/dbdeployer/dbdeployer" ] ; then
     return
   fi
-  ./dbdeployer deploy single "5.7.21" --sandbox-binary $PWD/sandbox/binary --sandbox-home $PWD/sandboxes --sandbox-directory orc-sandbox --port=3306
+
+  if [ -d "/mysql-tarballs-downloaded" ] ; then
+    # if we downloaded MySQL, use it for tests
+    tar_file=(/mysql-tarballs-downloaded/*)
+  else
+    # use bundled version
+    tar_file=(mysql-tarballs/*)
+  fi
+
+  mkdir -p ~/opt/mysql
+  /dbdeployer/dbdeployer unpack $tar_file
+
+  pushd ~/opt/mysql
+  version=(*)
+  popd
+ 
+  echo tar_file: $tar_file
+  echo version: $version
+
+  /dbdeployer/dbdeployer deploy single $version --sandbox-home $PWD/sandboxes --sandbox-directory orc-sandbox --port=3306
+
   mkdir -p bin
   ln -s /go/src/github.com/openark/orchestrator/sandboxes/orc-sandbox/use bin/mysql
   chmod +x bin/mysql

--- a/tests/system/test.sh
+++ b/tests/system/test.sh
@@ -165,6 +165,12 @@ test_step() {
       diff_result=$?
       if [ $diff_result -ne 0 ] ; then
         echo "ERROR $test_name/$test_step_name output does not match expect_output"
+	echo "TEST OUTPUT"
+        echo "---"
+	cat $test_outfile
+        echo "---"
+
+	echo "DIFF"
         echo "---"
         cat $test_diff_file
         echo "---"
@@ -311,7 +317,12 @@ test_all() {
           echo "$test_name" >> $tests_successful_file
         else
           echo "$test_name" >> $tests_failed_file
-          exit 1
+          if [ "$ALLOW_TESTS_FAILURES" != "YES" ] ; then
+            echo "Tests failures not allowed. Exiting."
+            exit 1
+          else
+            echo "Tests failures allowed. Continuing."
+          fi
         fi
       else
         : # echo "# should not attempt $test_name"


### PR DESCRIPTION
https://jira.percona.com/browse/DISTMYSQL-140

Adjusted Orchestrator's files to support parameterized Jenkins build.

1. MySql tarball passed as the parameter via env variable TARBALL_URL.
This allows testing the Orchestrator against the requested version
of MySql. If env variable not specified, fallback to the original,
hardcoded 5.7.26 version.
2. Allow tests continuation even if the test fails. (controlled via env
variable ALLOW_TESTS_FAILURES).
Originally the test suite was immediately finished on the 1st error.
3. Added convenience scripts test-system.sh and test-integration.sh
4. Use dbdeployer-1.64.0. This can be changed on Dockerfile level
5. Allow automatic start of system tests after container start
(controlled via env variable RUN_TESTS)
6. Allow use of custom Orchestrator's ci-env (controlled via env
variables CI_ENV_REPO and CI_ENV_BRANCH)