### PR TITLE
Implementing the small FR DISTMYSQL-182 as also suggested by customer…

### DIFF
--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -380,9 +380,14 @@ func ReadTopologyInstanceBufferable(instanceKey *InstanceKey, bufferWrites bool,
 
 	latency.Start("instance")
 	db, err := db.OpenDiscovery(instanceKey.Hostname, instanceKey.Port)
-	err = db.Ping()
-	latency.Stop("instance")
-	if err != nil {
+	if err == nil {
+		err = db.Ping()
+		latency.Stop("instance")
+		if err != nil {
+			goto Cleanup
+		}
+	}else{
+		latency.Stop("instance")
 		goto Cleanup
 	}
 

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -380,6 +380,7 @@ func ReadTopologyInstanceBufferable(instanceKey *InstanceKey, bufferWrites bool,
 
 	latency.Start("instance")
 	db, err := db.OpenDiscovery(instanceKey.Hostname, instanceKey.Port)
+	err = db.Ping()
 	latency.Stop("instance")
 	if err != nil {
 		goto Cleanup

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -386,7 +386,7 @@ func ReadTopologyInstanceBufferable(instanceKey *InstanceKey, bufferWrites bool,
 		if err != nil {
 			goto Cleanup
 		}
-	}else{
+	} else {
 		latency.Stop("instance")
 		goto Cleanup
 	}


### PR DESCRIPTION
… in the comments, just adding the <db>.Ping() to check if the instance is really available or not.
In my view this is more a bug fix than a FR. It makes no sense to have :
```
	db, err := db.OpenDiscovery(instanceKey.Hostname, instanceKey.Port)
	latency.Stop("instance")
	if err != nil {
		goto Cleanup
	}
```
Without checking the DB connectivity as well. 