### PR TITLE
DISTMYSQL-227 fixes when promoting co-master

### DIFF
--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -70,7 +70,7 @@ var isElectedNode int64 = 0
 
 var recentDiscoveryOperationKeys *cache.Cache
 var pseudoGTIDPublishCache = cache.New(time.Minute, time.Second)
-var kvFoundCache = cache.New(10*time.Minute, time.Minute)
+var kvFoundCache = cache.New(10*time.Second, time.Second)
 
 func init() {
 	snapshotDiscoveryKeys = make(chan inst.InstanceKey, 10)


### PR DESCRIPTION
- Reduces Orchestrator cache of K/V from Consul from 10 min to 10 sec
- Adds the code to submit changes of master to K/V when promoting the comaster
- Adds the logic to do RESET SLAVE ALL when promoting the comaster when ApplyMySQLPromotionAfterMasterFailover is true