### PR TITLE
"WARNING: NamedStopwatch.Stop("instance") IsRunning is false"

### DIFF
--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -380,16 +380,15 @@ func ReadTopologyInstanceBufferable(instanceKey *InstanceKey, bufferWrites bool,
 
 	latency.Start("instance")
 	db, err := db.OpenDiscovery(instanceKey.Hostname, instanceKey.Port)
-	if err == nil {
-		err = db.Ping()
-		latency.Stop("instance")
-		if err != nil {
-			goto Cleanup
-		}
-	} else {
+	if err != nil {
 		latency.Stop("instance")
 		goto Cleanup
 	}
+	err = db.Ping()
+	if err != nil {
+		goto Cleanup
+	}
+	latency.Stop("instance")
 
 	instance.Key = *instanceKey
 


### PR DESCRIPTION
https://jira.percona.com/browse/DISTMYSQL-232

The problem is caused by NamedStopwatch implementation which writes this warning. There is no way to suppress this warning. NamedStopwatch also does not have a method like IsRunning() to learn its state.

The problem was that stopwatch was stopped after the error returned by Ping(). The cleanup part of the function expects the stopwatch to be started.

Please note that the original code suffers the same problem. If OpenDiscovery() failed, the stopwatch was stopped and the control directly went to Cleanup causing a warning print. The same is for the branch after checkMaxScale() call.

As there were no complaints about the original behavior I decided to solve the problem in the simplest way. In case of Ping() failure, we do not stop the stopwatch and go directly to Cleanup.