### PR TITLE
DISTMYSQL-249: Orchestrator analysis-locked-hypothesis test is unstable

### DIFF
--- a/tests/system/analysis-locked-semi-sync-master/01-analysis-locked-hypothesis/setup
+++ b/tests/system/analysis-locked-semi-sync-master/01-analysis-locked-hypothesis/setup
@@ -10,4 +10,4 @@ orchestrator-client -c enable-semi-sync-replica -i 127.0.0.1:10112
 sleep 2
 
 orchestrator-client -c disable-semi-sync-replica -i 127.0.0.1:10112
-sleep 2
+sleep 7


### PR DESCRIPTION
https://jira.percona.com/browse/DISTMYSQL-249

Problem:
analysis-locked-hypothesis test is unstable

Cause:
By default instance is polled every 5 seconds, but we wait only for 2 seconds, so it may happen that instance is not polled before we get the analysis result.

Solution:
Wait for 7 seconds after disabling instance. It is 7 because it has to be > 5 but LockedSemiSyncMasterHypothesis is reported only within 6 secs window (InstancePollSeconds + ReasonableInstanceCheckSeconds), then it switches to LockedSemiSyncMaster status.