### PR TITLE
DISTMYSQL-243 - Orchestrator uses inefficient subquery in REPLACE to …

### DIFF
--- a/go/inst/cluster_alias_dao.go
+++ b/go/inst/cluster_alias_dao.go
@@ -126,16 +126,15 @@ func UpdateClusterAliases() error {
 				    left join database_instance_downtime using (hostname, port)
 				  where
 				    suggested_cluster_alias!=''
+						and cluster_name != ''
 						/* exclude newly demoted, downtimed masters */
 						and ifnull(
 								database_instance_downtime.downtime_active = 1
 								and database_instance_downtime.end_timestamp > now()
 								and database_instance_downtime.reason = ?
 							, 0) = 0
-					order by
-						ifnull(last_checked <= last_seen, 0) asc,
-						read_only desc,
-						num_slave_hosts asc
+					group by
+					       suggested_cluster_alias, cluster_name
 			`, DowntimeLostInRecoveryMessage)
 		return log.Errore(err)
 	}


### PR DESCRIPTION
…update cluster aliases

Problem:
--------
Orchestrator has backend table cluster_alias to store aliases. At certain intervals, orchestrator will update the aliases or insert new host aliases. To do this, it uses the below query in UpdateClusterAliases():
```
			replace into
					cluster_alias (alias, cluster_name, last_registered)
				select
				    suggested_cluster_alias,
						cluster_name,
						now()
					from
				    database_instance
				    left join database_instance_downtime using (hostname, port)
				  where
				    suggested_cluster_alias!=''
						/* exclude newly demoted, downtimed masters */
						and ifnull(
								database_instance_downtime.downtime_active = 1
								and database_instance_downtime.end_timestamp > now()
								and database_instance_downtime.reason = ?
							, 0) = 0
					order by
						ifnull(last_checked <= last_seen, 0) asc,
						read_only desc,
						num_slave_hosts asc

```

The problem with the select query is it will generated the same alias,cluster_name multiple times. REPLACE does this operation by doing DELETE+INSERT. REPLACE repeatedly does the same work for all the duplicated records.

This creates un-necessary work for two sub systems in InnoDB
1. Purge
2. SELECTS (ReadView)

All those delete marked records create stress on Purge. SELECTs, when they have to build a older version of record, they have to build a long chain of old version records (using undo log). So the un-necessary REPLACE work will create a long chain of records to be built.

Fix:
----
Use GROUPBY to filter duplicate records in subquery in REPLACE.

<!--
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR
-->

Related issue: https://github.com/openark/orchestrator/issues/0123456789


### Description

This PR [briefly explain what is does]

<!--
Please make sure that:

- [ ] contributed code is using same conventions as original code

Please make sure the PR passes CI tests. For your information, CI tests the following:

- code is formatted via `gofmt` (please avoid `goimports`)
- code passes compilation
- code passes unit tests
- code passes integration tests with MySQL backend
- code passes integration tests with SQLite backend
- There are no orphaned docs/ pages (there's some link in the docs to point to any page)
- upgrade from previous version (`master` branch) is successful
 -->
