### PR TITLE
Fix for issue #16, needed to remove deprecated parameters for go buil…

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -84,7 +84,7 @@ function precheck() {
     ok=1
   fi
 
-  if ! go version | egrep -q 'go(1\.1[6789])' ; then
+  if ! go version | egrep -q 'go(1\.1[6789])|go(1\.2[0])' ; then
     echo "go version must be 1.16 or above"
     ok=1
   fi
@@ -115,7 +115,7 @@ build_binary() {
   debug "Building via $(go version)"
   mkdir -p "$binary_build_path/bin"
   rm -f $binary_artifact
-  gobuild="go build -i ${opt_race} -ldflags \"$ldflags\" -o $binary_artifact go/cmd/orchestrator/main.go"
+  gobuild="go build ${opt_race} -ldflags \"$ldflags\" -o $binary_artifact go/cmd/orchestrator/main.go"
 
   case $os in
     'linux')

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@
 # ORC_USER (default: orc_server_user): username used to login to orchestrator backend MySQL server
 # ORC_PASSWORD (default: orc_server_password): password used to login to orchestrator backend MySQL server
 
-FROM golang:1.16.6-alpine3.14 as build
+FROM golang:1.20.3-alpine3.17 as build
 
 ENV GOPATH=/tmp/go
 
@@ -28,7 +28,7 @@ RUN rsync -av $(find /tmp/orchestrator-release -type d -name orchestrator -maxde
 RUN rsync -av $(find /tmp/orchestrator-release -type d -name orchestrator-client -maxdepth 2)/ /
 RUN cp conf/orchestrator-sample-sqlite.conf.json /etc/orchestrator.conf.json
 
-FROM alpine:3.14
+FROM alpine:3.17
 
 RUN apk --no-cache add bash curl jq
 

--- a/docker/Dockerfile.packaging
+++ b/docker/Dockerfile.packaging
@@ -14,11 +14,11 @@
 # ORC_USER (default: orc_server_user): username used to login to orchestrator backend MySQL server
 # ORC_PASSWORD (default: orc_server_password): password used to login to orchestrator backend MySQL server
 
-FROM golang:1.16.6-stretch
+FROM golang:1.20.3-bullseye
 
 RUN apt-get update
 RUN apt-get install -y ruby ruby-dev rubygems build-essential
-RUN gem install --no-ri --no-rdoc fpm
+RUN gem install --no-document fpm
 ENV GOPATH=/tmp/go
 
 RUN apt-get install -y curl rsync gcc g++ bash git tar rpm

--- a/docker/Dockerfile.raft
+++ b/docker/Dockerfile.raft
@@ -1,4 +1,4 @@
-FROM golang:1.16.6-stretch
+FROM golang:1.20.3-bullseye
 LABEL maintainer="openark@github.com"
 
 RUN apt-get update -q -y

--- a/docker/Dockerfile.system
+++ b/docker/Dockerfile.system
@@ -8,7 +8,7 @@ RUN echo "ci_env_repo: $ci_env_repo"
 RUN echo "ci_env_branch: $ci_env_branch"
 
 RUN apt-get update -q -y
-RUN apt-get install -y sudo haproxy python git jq rsync libaio1 libnuma1 mysql-client bsdmainutils less vim
+RUN apt-get install -y sudo haproxy python git jq rsync libaio1 libnuma1 default-mysql-client bsdmainutils less vim
 
 RUN mkdir /orchestrator
 WORKDIR /orchestrator

--- a/docker/Dockerfile.system
+++ b/docker/Dockerfile.system
@@ -1,4 +1,4 @@
-FROM golang:1.16.6-stretch
+FROM golang:1.20.3-bullseye
 LABEL maintainer="openark@github.com"
 
 ARG ci_env_repo="https://github.com/percona/orchestrator-ci-env.git"

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.16.6-stretch
+FROM golang:1.20.3-bullseye
 LABEL maintainer="openark@github.com"
 
 RUN apt-get update

--- a/docker/docker-entry-raft
+++ b/docker/docker-entry-raft
@@ -34,6 +34,9 @@ done
 echo "export PS1=\"\\[\\e[0;33m\\]\\h \\[\\e[0;97m\\]\\w\\[\\e[0;37m\\]\\\$ \"" >> /etc/bash.bashrc
 echo 'export ORCHESTRATOR_API="http://127.0.0.1:3007/api http://127.0.0.1:3008/api http://127.0.0.1:3009/api"' | sudo tee /etc/profile.d/orchestrator-client.sh
 
+# wait for registration and election
+sleep 10
+
 echo ""
 echo "Here's how to invoke orchestrator-client:"
 echo "---"

--- a/script/build
+++ b/script/build
@@ -27,6 +27,6 @@ export GOPATH="$PWD/.gopath"
 cd .gopath/src/github.com/openark/orchestrator
 
 # We put the binaries directly into the bindir, because we have no need for shim wrappers
-go build -i -o "$bindir/orchestrator" -ldflags "-X main.AppVersion=${version} -X main.BuildDescribe=${describe}" ./go/cmd/orchestrator/main.go
+go build -o "$bindir/orchestrator" -ldflags "-X main.AppVersion=${version} -X main.BuildDescribe=${describe}" ./go/cmd/orchestrator/main.go
 
 rsync -qa ./resources $bindir/

--- a/script/ensure-go-installed
+++ b/script/ensure-go-installed
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-PREFERRED_GO_VERSION=go1.16.6
-SUPPORTED_GO_VERSIONS='go1.1[6789]'
+PREFERRED_GO_VERSION=go1.20.3
+SUPPORTED_GO_VERSIONS='go1.1[6789]|go1.2[0]'
 
 export ROOTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 cd $ROOTDIR
 
 # If Go isn't installed globally, setup environment variables for local install.
-if [ -z "$(which go)" ] || [ -z "$(go version | grep "$SUPPORTED_GO_VERSIONS")" ]; then
+if [ -z "$(which go)" ] || [ -z "$(go version | egrep "$SUPPORTED_GO_VERSIONS")" ]; then
   GODIR="$ROOTDIR/.vendor/golocal"
 
   if [ $(uname -s) = "Darwin" ]; then
@@ -20,7 +20,7 @@ if [ -z "$(which go)" ] || [ -z "$(go version | grep "$SUPPORTED_GO_VERSIONS")" 
 fi
 
 # Fail if correct go version still unfound
-if [ -z "$(which go)" ] || [ -z "$(go version | grep "$SUPPORTED_GO_VERSIONS")" ]; then
+if [ -z "$(which go)" ] || [ -z "$(go version | egrep "$SUPPORTED_GO_VERSIONS")" ]; then
   exit 1
 fi
 


### PR DESCRIPTION
Fixing issue 16, raised the go version to 1.20, removed deprecated "go build" and "gem install" options so the build and docker images work.  Also updated the Dockerfiles to use up to date images.