### PR TITLE
Distmysql-185

### DIFF
--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -2815,7 +2815,7 @@ func relocateReplicasInternal(replicas [](*Instance), instance, other *Instance)
 	}
 
 	// GTID
-	if other.UsingGTID() {
+	{
 
 		movedReplicas, unmovedReplicas, err, errs := moveReplicasViaGTID(replicas, other, nil)
 


### PR DESCRIPTION
This PL improves the error message returned when there are sub-errors reported. A good example of this is when a replica that does not have log_slave_updates is to be promoted to master.  Now the error message will include the sub-error about log_slave_updates. See: https://jira.percona.com/browse/DISTMYSQL-185

Tests Passed: https://ps80.cd.percona.com/job/mysql-orchestrator-pipeline/8/console
