### PR TITLE
DISTMYSQL-170: Orchestrator GUI: group multiple errantgtidstructure warning icons

### DIFF
--- a/resources/public/css/orchestrator.css
+++ b/resources/public/css/orchestrator.css
@@ -1011,3 +1011,9 @@ body {
 .instance.instance-search p {
     margin: 8px 0px;
 }
+
+.overlay-counter {
+    margin-left:-5px;
+    font-size: 0.65em;
+    font-weight: bold;
+}


### PR DESCRIPTION
https://jira.percona.com/browse/DISTMYSQL-170

Problem:
Warning icon is displayed for every cluster analysis problem detected. If there is a lot of problems, a lot of warning icons in row is displayed making GUI unreadable.

Solution:
Group 'warings', 'dangers', and 'muted' notifications, display small number next to the icon indicating that grouping took place. Display all warnings list when mouse pointer is hoofed over the icon.

Additionally fixed the way cluster analysis problems (clustersAnalysisProblems map) were collected. When analysis entry contained one or several strructure analysis entries, adding them to the array caused overwriting of all previously added entries. It was because the loop always modified the same object's 'Analysis' member instead of assigning structureAnalysis to the new object's 'Analysis' member.
Fixed by shallow cloning of the original object. Shallow copy is enough because 'AnalyzedInstanceKey' can point to the same object. Only what was pointed by 'Analysis' was problematic.