### PR TITLE
DISTMYSQL-169: Make tags visible in the GUI

### DIFF
--- a/resources/public/css/orchestrator.css
+++ b/resources/public/css/orchestrator.css
@@ -143,6 +143,10 @@ body {
     cursor: default;
 }
 
+.instance h3 .glyphicon-tags {
+    margin-right: 0.4em;
+}
+
 .instance h3 .instance-glyphs {
     cursor: pointer;
 }

--- a/resources/public/js/orchestrator.js
+++ b/resources/public/js/orchestrator.js
@@ -385,6 +385,14 @@ function openNodeModal(node) {
   addNodeModalDataAttribute("Agent",
     '<a href="' + appUrl('/web/agent/' + node.Key.Hostname) + '">' + node.Key.Hostname + '</a>');
 
+  var tagsText = "";
+  if (node.hasOwnProperty('tagStrings') && node.tagStrings.length) {
+    node.tagStrings.forEach(function(tag){
+      tagsText = tagsText.concat(tag, '<br>');
+    });
+  }
+  addNodeModalDataAttribute("Tags", tagsText);
+
   $('#node_modal [data-btn]').unbind("click");
 
   $("#beginDowntimeOwner").val(getUserId());


### PR DESCRIPTION
https://jira.percona.com/browse/DISTMYSQL-169

Problem:
Instance tags are not visible in Orchestrator's web GUI.

Solution:
1. If instance tags are present, 'tags' icon is displayed on the top bar of the instance. When the mouse is hovered on, tags are displayed.
2. Added new row 'Tags' to instance modal view.

Additionally fixed handling of /api/recently-active-cluster-recovery
endpoint result.