### PR TITLE
bugfix:When the Master is down, the region or datacenter detects abno…

### DIFF
--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -646,6 +646,54 @@ func ReadTopologyInstanceBufferable(instanceKey *InstanceKey, bufferWrites bool,
 		// This can be overriden by later invocation of DetectPhysicalEnvironmentQuery
 	}
 
+	// Get datacenter/region etc
+	func() {
+		var getMetaWaitGroup sync.WaitGroup
+		if config.Config.DetectDataCenterQuery != "" && !isMaxScale {
+			getMetaWaitGroup.Add(1)
+			go func() {
+				defer getMetaWaitGroup.Done()
+				err := db.QueryRow(config.Config.DetectDataCenterQuery).Scan(&instance.DataCenter)
+				logReadTopologyInstanceError(instanceKey, "DetectDataCenterQuery", err)
+			}()
+		}
+		if config.Config.DetectRegionQuery != "" && !isMaxScale {
+			getMetaWaitGroup.Add(1)
+			go func() {
+				defer getMetaWaitGroup.Done()
+				err := db.QueryRow(config.Config.DetectRegionQuery).Scan(&instance.Region)
+				logReadTopologyInstanceError(instanceKey, "DetectRegionQuery", err)
+			}()
+		}
+		if config.Config.DetectPhysicalEnvironmentQuery != "" && !isMaxScale {
+			getMetaWaitGroup.Add(1)
+			go func() {
+				defer getMetaWaitGroup.Done()
+				err := db.QueryRow(config.Config.DetectPhysicalEnvironmentQuery).Scan(&instance.PhysicalEnvironment)
+				logReadTopologyInstanceError(instanceKey, "DetectPhysicalEnvironmentQuery", err)
+			}()
+		}
+
+		if config.Config.DetectInstanceAliasQuery != "" && !isMaxScale {
+			getMetaWaitGroup.Add(1)
+			go func() {
+				defer getMetaWaitGroup.Done()
+				err := db.QueryRow(config.Config.DetectInstanceAliasQuery).Scan(&instance.InstanceAlias)
+				logReadTopologyInstanceError(instanceKey, "DetectInstanceAliasQuery", err)
+			}()
+		}
+
+		if config.Config.DetectSemiSyncEnforcedQuery != "" && !isMaxScale {
+			getMetaWaitGroup.Add(1)
+			go func() {
+				defer getMetaWaitGroup.Done()
+				err := db.QueryRow(config.Config.DetectSemiSyncEnforcedQuery).Scan(&instance.SemiSyncPriority)
+				logReadTopologyInstanceError(instanceKey, "DetectSemiSyncEnforcedQuery", err)
+			}()
+		}
+		getMetaWaitGroup.Wait()
+	}()
+
 	instance.ReplicationIOThreadState = ReplicationThreadStateNoThread
 	instance.ReplicationSQLThreadState = ReplicationThreadStateNoThread
 	err = sqlutils.QueryRowsMap(db, "show slave status", func(m sqlutils.RowMap) error {
@@ -832,51 +880,6 @@ func ReadTopologyInstanceBufferable(instanceKey *InstanceKey, bufferWrites bool,
 				})
 
 			logReadTopologyInstanceError(instanceKey, "ndbinfo", err)
-		}()
-	}
-
-	if config.Config.DetectDataCenterQuery != "" && !isMaxScale {
-		waitGroup.Add(1)
-		go func() {
-			defer waitGroup.Done()
-			err := db.QueryRow(config.Config.DetectDataCenterQuery).Scan(&instance.DataCenter)
-			logReadTopologyInstanceError(instanceKey, "DetectDataCenterQuery", err)
-		}()
-	}
-
-	if config.Config.DetectRegionQuery != "" && !isMaxScale {
-		waitGroup.Add(1)
-		go func() {
-			defer waitGroup.Done()
-			err := db.QueryRow(config.Config.DetectRegionQuery).Scan(&instance.Region)
-			logReadTopologyInstanceError(instanceKey, "DetectRegionQuery", err)
-		}()
-	}
-
-	if config.Config.DetectPhysicalEnvironmentQuery != "" && !isMaxScale {
-		waitGroup.Add(1)
-		go func() {
-			defer waitGroup.Done()
-			err := db.QueryRow(config.Config.DetectPhysicalEnvironmentQuery).Scan(&instance.PhysicalEnvironment)
-			logReadTopologyInstanceError(instanceKey, "DetectPhysicalEnvironmentQuery", err)
-		}()
-	}
-
-	if config.Config.DetectInstanceAliasQuery != "" && !isMaxScale {
-		waitGroup.Add(1)
-		go func() {
-			defer waitGroup.Done()
-			err := db.QueryRow(config.Config.DetectInstanceAliasQuery).Scan(&instance.InstanceAlias)
-			logReadTopologyInstanceError(instanceKey, "DetectInstanceAliasQuery", err)
-		}()
-	}
-
-	if config.Config.DetectSemiSyncEnforcedQuery != "" && !isMaxScale {
-		waitGroup.Add(1)
-		go func() {
-			defer waitGroup.Done()
-			err := db.QueryRow(config.Config.DetectSemiSyncEnforcedQuery).Scan(&instance.SemiSyncPriority)
-			logReadTopologyInstanceError(instanceKey, "DetectSemiSyncEnforcedQuery", err)
 		}()
 	}
 


### PR DESCRIPTION
Hi
My English is so-so, I use Google translate, sorry, Thank you.

## Issue
- [region or datacenter causes failover to fail #1455](https://github.com/openark/orchestrator/issues/1455)

## Triggering conditions
* PreventCrossRegionMasterFailover = true
* PreventCrossDataCenterMasterFailover = true

Satisfy any one or enable both

## trigger timing
not necessarily，Once there, the impact is very serious

## How to reproduce
1. When ORC scans the instance status, the Master node is normal at this time, and ORC will mark the current Master node instanceFound=true
2. The master node is suddenly shut down or other unreachable faults
3. At this time, ORC will continue to execute DetectRegionQuery, DetectDataCenterQuery and other operations (non-matching configuration file regular part)
4. The master node has been down, so naturally the results cannot be obtained
5. Update the null value to the table orchestrator.database_instance, you can see that the Master node region is empty
    ![20230619-112525](https://github.com/percona/orchestrator/assets/14190782/aa15ae8c-1b60-4806-bf05-169c4e7e05ec)
6. If Failover is performed at this time, the value of analysisEntry.AnalyzedInstanceRegion will be empty, causing the region or datacenter verification to fail, and the failover will fail.

## Steps to reproduce
### topology
![20230619-113005](https://github.com/percona/orchestrator/assets/14190782/5e317ecc-eb89-4d46-9a50-0728224e6496)

### debug code
go/inst/instance_dao.go
> Add a for loop under instanceFound = true (you can take as many seconds as you want, don’t be too big, if it is too big, the detection will be too slow, and the effect will appear slowly)

![image](https://github.com/percona/orchestrator/assets/14190782/a92ef55d-bbff-4063-ad26-630581373ce0)

### Reboot Orchestrator
```shell
go run go/cmd/orchestrator/main.go -config conf/orchestrator.conf.json  -debug http
```

### Shutdown the Master node
> Here you need to choose a good timing. The timing is the 5-second logic of debugging the code. The shutdown command should be executed during the 5-second period of the Loop.

![image](https://github.com/percona/orchestrator/assets/14190782/5479bdc9-8fae-4fb2-b940-aa90c5b4affb)

### observe topology
At this time, the topology restoration fails, and the restoration failure will form a cascade topology.

![image](https://github.com/percona/orchestrator/assets/14190782/a6b9b935-4913-4092-be9e-6243fbd1f759)

### Observe the Recovery log
![image](https://github.com/percona/orchestrator/assets/14190782/0eca183d-7622-461f-be19-2188635294da)
![image](https://github.com/percona/orchestrator/assets/14190782/6f07c763-0853-4abb-92b1-eb73b37e43a5)
![image](https://github.com/percona/orchestrator/assets/14190782/523e7390-8b06-4265-9b37-afa8282e9235)

### Observe the records of the Orchestrator table
![image](https://github.com/percona/orchestrator/assets/14190782/f11717c9-97d9-4091-bcd6-3f7887f8f0fb)

