### PR TITLE
DISTMYSQL-364: Adding the detection of Percona server as candidate fo…

### DIFF
--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -706,12 +706,13 @@ func ReadTopologyInstanceBufferable(instanceKey *InstanceKey, bufferWrites bool,
 	if err != nil {
 		goto Cleanup
 	}
-	// Populate GR information for the instance in Oracle MySQL 8.0+. To do this we need to wait for the Server UUID to
-	// be populated to be able to find this instance's information in performance_schema.replication_group_members by
-	// comparing UUIDs. We could instead resolve the MEMBER_HOST and MEMBER_PORT columns into an InstanceKey and compare
-	// those instead, but this could require external calls for name resolving, whereas comparing UUIDs does not.
+	// Populate GR information for the instance in Oracle MySQL 8.0+ or Percona Server 8.0+. To do this we need to wait
+	// for the Server UUID to be populated to be able to find this instance's information in
+	// performance_schema.replication_group_members by comparing UUIDs. We could instead resolve the MEMBER_HOST and
+	// MEMBER_PORT columns into an InstanceKey and compare those instead, but this could require external calls for
+	// name resolving, whereas comparing UUIDs does not.
 	serverUuidWaitGroup.Wait()
-	if instance.IsOracleMySQL() && !instance.IsSmallerMajorVersionByString("8.0") {
+	if (instance.IsOracleMySQL() || instance.IsPercona()) && !instance.IsSmallerMajorVersionByString("8.0") {
 		err := PopulateGroupReplicationInformation(instance, db)
 		if err != nil {
 			goto Cleanup


### PR DESCRIPTION
Addressing: https://jira.percona.com/browse/DISTMYSQL-364

This diff is fairly trivial.  Currently, Orchestrator monitors/discovers group replication topologies only if it is Oracle MySQL ver. 8.0+.  Since Percona Server is very close, code wise, to Oracle MySQL and that group replication works equally well on Percona server, Orchestrator should be able to discover a Group replication even when Percona Server is used.

There are currently very limited support for Group replication in Orchestrator, it just discovers and reports what is there.  As such, there are no built-in tests specific for group replication.

Passed the Jenkins mysql-orchestrator-pipeline successfully. 