### PR TITLE
DISTMYSQL-396: Fix for DISTMYSQL-243 can lead to Orchestrator hitting…

### DIFF
--- a/script/ensure-go-installed
+++ b/script/ensure-go-installed
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 PREFERRED_GO_VERSION=go1.20.3
-SUPPORTED_GO_VERSIONS='go1.1[6789]|go1.2[0]'
+SUPPORTED_GO_VERSIONS='go1.1[6789]|go1.2[01]'
 
 export ROOTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 cd $ROOTDIR


### PR DESCRIPTION
… duplicate keys

https://perconadev.atlassian.net/browse/DISTMYSQL-396

Fix for DISTMYSQL-243 didn't consider the case when two clusters have the same suggested custer aliases (the value of it can originate from ClusterNameToAlias, DetectClusterAliasQuery or be set manually by the user). In such a case we end up with the situation like:

> create table t1 (a int primary key, b int, unique key (b));
> insert into t1 values (0, 1);
> insert into t1 values (1, 2);
> insert into t1 values (0, 2) on duplicate key update a=0, b=2;
ERROR 1062 (23000): Duplicate entry '2' for key 't1.b'

The fix implements the fallback to REPLACE INTO approach in case of the failure of the optimized approach using
INSERT INTO ... ON DUPLICATE KEY.

<!--
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR
-->

Related issue: https://github.com/openark/orchestrator/issues/0123456789


### Description

This PR [briefly explain what is does]

<!--
Please make sure that:

- [ ] contributed code is using same conventions as original code

Please make sure the PR passes CI tests. For your information, CI tests the following:

- code is formatted via `gofmt` (please avoid `goimports`)
- code passes compilation
- code passes unit tests
- code passes integration tests with MySQL backend
- code passes integration tests with SQLite backend
- There are no orphaned docs/ pages (there's some link in the docs to point to any page)
- upgrade from previous version (`master` branch) is successful
 -->
