### PR TITLE
DISTMYSQL-406: Orchestrator exposes MySQLOrchestratorPassword variable

### DIFF
--- a/go/db/db.go
+++ b/go/db/db.go
@@ -131,7 +131,7 @@ func openOrchestratorMySQLGeneric() (db *sql.DB, fromCache bool, err error) {
 	if config.Config.MySQLOrchestratorUseMutualTLS {
 		uri, _ = SetupMySQLOrchestratorTLS(uri)
 	}
-	sqlUtilsLogger := SqlUtilsLogger{client_context: config.Config.MySQLOrchestratorHost + ":" + config.Config.MySQLOrchestratorHost}
+	sqlUtilsLogger := SqlUtilsLogger{client_context: config.Config.MySQLOrchestratorHost + ":" + strconv.FormatUint(uint64(config.Config.MySQLOrchestratorPort), 10)}
 	return sqlutils.GetDB(uri, sqlUtilsLogger)
 }
 
@@ -200,7 +200,7 @@ func OpenOrchestrator() (db *sql.DB, err error) {
 			}
 		}
 		dsn := getMySQLURI()
-		sqlUtilsLogger := SqlUtilsLogger{client_context: dsn}
+		sqlUtilsLogger := SqlUtilsLogger{client_context: config.Config.MySQLOrchestratorHost + ":" + strconv.FormatUint(uint64(config.Config.MySQLOrchestratorPort), 10)}
 		db, fromCache, err = sqlutils.GetDB(dsn, sqlUtilsLogger)
 		if err == nil && !fromCache {
 			log.Debugf("Connected to orchestrator backend: %v", safeMySQLURI(dsn))


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/DISTMYSQL-406

Problem:
Error log contains password of Orchestrator's backend database

Cause:
Commit b8b30e69 passed the whole connection URI to the logger as a context to be displayed together with logs. The problem was only for Orchestrator's backend database. Managed instances were unaffected.

Solution:
Pass only host and port as a context to be displayed together with logs.