### PR TITLE
More flexibility with setting the release version for `./script/dock pkg`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -227,7 +227,7 @@ package_linux() {
   [ $do_rpm -eq 1 ] && fpm -v "${RELEASE_VERSION}" --epoch 1  -f -s dir -n orchestrator-client -m shlomi-noach --description "MySQL replication topology management and HA: client script" --url "https://github.com/openark/orchestrator" --vendor "GitHub" --license "Apache 2.0" -C $build_path/orchestrator-client --prefix=/ --depends 'jq >= 1.5' -t rpm .
   [ $do_deb -eq 1 ] && fpm -v "${RELEASE_VERSION}" --epoch 1  -f -s dir -n orchestrator-client -m shlomi-noach --description "MySQL replication topology management and HA: client script" --url "https://github.com/openark/orchestrator" --vendor "GitHub" --license "Apache 2.0" -C $build_path/orchestrator-client --prefix=/ --depends 'jq >= 1.5' -t deb --deb-no-default-config-files .
 
-  if [ ! -z "$package_name_extra" ] ; then
+  if [ -n "$package_name_extra" ] ; then
     # Strip version core out of sting like "3.2.6-pre123+g1234567" to "3.2.6".
     # We need it because `-` is converted to `_` in rpm package name,
     # and `+` have a special meaning for `sed`.
@@ -281,7 +281,7 @@ main() {
   local build_only=$5
   local build_path
 
-  if [ "${RELEASE_VERSION}" == "" ] ; then
+  if [ -z "${RELEASE_VERSION}" ] ; then
     RELEASE_VERSION=$(cat $basedir/RELEASE_VERSION)
   fi
   RELEASE_VERSION="${RELEASE_VERSION}${RELEASE_SUBVERSION}"

--- a/build.sh
+++ b/build.sh
@@ -8,8 +8,8 @@ set -e
 
 basedir=$(dirname $0)
 GIT_COMMIT=$(git rev-parse HEAD)
-RELEASE_VERSION=
-RELEASE_SUBVERSION=
+RELEASE_VERSION=${RELEASE_VERSION:-""}
+RELEASE_SUBVERSION=${RELEASE_SUBVERSION:-""}
 release_base_path=/tmp/orchestrator-release
 export RELEASE_VERSION release_base_path
 
@@ -36,8 +36,8 @@ usage() {
   echo "-R retain existing build/deployment paths"
   echo "-p build prefix Default:(/usr/local)"
   echo "-r build with race detector"
-  echo "-v release version (optional; default: content of RELEASE_VERSION file)"
-  echo "-s release subversion (optional; default: empty)"
+  echo "-v release version (optional; default: the value of RELEASE_VERSION environment variable, or content of RELEASE_VERSION file)"
+  echo "-s release subversion (optional; default: the value of RELEASE_SUBVERSION environment variable, or empty)"
   echo
 }
 
@@ -228,8 +228,12 @@ package_linux() {
   [ $do_deb -eq 1 ] && fpm -v "${RELEASE_VERSION}" --epoch 1  -f -s dir -n orchestrator-client -m shlomi-noach --description "MySQL replication topology management and HA: client script" --url "https://github.com/openark/orchestrator" --vendor "GitHub" --license "Apache 2.0" -C $build_path/orchestrator-client --prefix=/ --depends 'jq >= 1.5' -t deb --deb-no-default-config-files .
 
   if [ ! -z "$package_name_extra" ] ; then
-    ls *.rpm | while read f; do package_file=$(echo $f | sed -r -e "s/^(.*)-${RELEASE_VERSION}(.*)/\1${package_name_extra}-${RELEASE_VERSION}\2/g") ; mv $f $package_file ; done
-    ls *.deb | while read f; do package_file=$(echo $f | sed -r -e "s/^(.*)_${RELEASE_VERSION}(.*)/\1${package_name_extra}-${RELEASE_VERSION}\2/g") ; mv $f $package_file ; done
+    # Strip version core out of sting like "3.2.6-pre123+g1234567" to "3.2.6".
+    # We need it because `-` is converted to `_` in rpm package name,
+    # and `+` have a special meaning for `sed`.
+    VERSION_CORE=$(echo $RELEASE_VERSION | sed -r -e "s/^([0-9]+\.[0-9]+\.[0-9]+).*$/\1/g")
+    ls *.rpm | while read f; do package_file=$(echo $f | sed -r -e "s/^(.*)-${VERSION_CORE}(.*)/\1${package_name_extra}-${VERSION_CORE}\2/g") ; mv $f $package_file ; done
+    ls *.deb | while read f; do package_file=$(echo $f | sed -r -e "s/^(.*)_${VERSION_CORE}(.*)/\1${package_name_extra}-${VERSION_CORE}\2/g") ; mv $f $package_file ; done
   fi
 
   debug "packeges:"
@@ -277,7 +281,7 @@ main() {
   local build_only=$5
   local build_path
 
-  if [ -z "${RELEASE_VERSION}" ] ; then
+  if [ "${RELEASE_VERSION}" == "" ] ; then
     RELEASE_VERSION=$(cat $basedir/RELEASE_VERSION)
   fi
   RELEASE_VERSION="${RELEASE_VERSION}${RELEASE_SUBVERSION}"

--- a/docker/Dockerfile.packaging
+++ b/docker/Dockerfile.packaging
@@ -26,6 +26,8 @@ RUN apt-get install -y curl rsync gcc g++ bash git tar rpm
 RUN mkdir -p $GOPATH/src/github.com/openark/orchestrator
 WORKDIR $GOPATH/src/github.com/openark/orchestrator
 COPY . .
+ARG RELEASE_VERSION=
+ARG RELEASE_SUBVERSION=
 RUN bash build.sh -b -P
 RUN bash build.sh -R -N -i sysv
 RUN bash build.sh -R -N -i systemd

--- a/script/dock
+++ b/script/dock
@@ -49,17 +49,23 @@ case "$command" in
   "pkg")
     packages_path="${2:-/tmp/orchestrator-release}"
     docker_target="orchestrator-packaging"
-    docker build . -f docker/Dockerfile.packaging -t "${docker_target}" && docker run --rm -it -v "${packages_path}:/tmp/pkg" "${docker_target}:latest" bash -c 'find /tmp/orchestrator-release/ -maxdepth 1 -type f | xargs cp -t /tmp/pkg'
+    docker build . --build-arg RELEASE_VERSION=${RELEASE_VERSION} \
+      --build-arg RELEASE_SUBVERSION=${RELEASE_SUBVERSION} \
+      -f docker/Dockerfile.packaging \
+      -t "${docker_target}" \
+      && docker run --rm -it -v "${packages_path}:/tmp/pkg" "${docker_target}:latest" \
+        bash -c 'find /tmp/orchestrator-release/ -maxdepth 1 -type f \
+      | xargs cp -t /tmp/pkg'
     echo "packages generated on ${packages_path}:"
     ls -l "${packages_path}"
     ;;
   "system")
     docker_target="orchestrator-system"
-    docker build . -f docker/Dockerfile.system -t "${docker_target}" --build-arg ci_env_repo=${CI_ENV_REPO_ENV} --build-arg ci_env_branch=${CI_ENV_BRANCH_ENV} && docker run --rm -it -p 3000:3000 --env TARBALL_URL=${TARBALL_URL} --env RUN_TESTS=${RUN_TESTS} --env ALLOW_TESTS_FAILURES=${ALLOW_TESTS_FAILURES} "${docker_target}:latest" 
+    docker build . -f docker/Dockerfile.system -t "${docker_target}" --build-arg ci_env_repo=${CI_ENV_REPO_ENV} --build-arg ci_env_branch=${CI_ENV_BRANCH_ENV} && docker run --rm -it -p 3000:3000 --env TARBALL_URL=${TARBALL_URL} --env RUN_TESTS=${RUN_TESTS} --env ALLOW_TESTS_FAILURES=${ALLOW_TESTS_FAILURES} "${docker_target}:latest"
     ;;
   "system-no-it")
     docker_target="orchestrator-system"
-    docker build . -f docker/Dockerfile.system -t "${docker_target}" --build-arg ci_env_repo=${CI_ENV_REPO_ENV} --build-arg ci_env_branch=${CI_ENV_BRANCH_ENV} && docker run --rm --env TARBALL_URL=${TARBALL_URL} --env RUN_TESTS=${RUN_TESTS} --env ALLOW_TESTS_FAILURES=${ALLOW_TESTS_FAILURES} "${docker_target}:latest" 
+    docker build . -f docker/Dockerfile.system -t "${docker_target}" --build-arg ci_env_repo=${CI_ENV_REPO_ENV} --build-arg ci_env_branch=${CI_ENV_BRANCH_ENV} && docker run --rm --env TARBALL_URL=${TARBALL_URL} --env RUN_TESTS=${RUN_TESTS} --env ALLOW_TESTS_FAILURES=${ALLOW_TESTS_FAILURES} "${docker_target}:latest"
     ;;
   "raft")
     docker_target="orchestrator-raft"


### PR DESCRIPTION
* Allow to set RELEASE_VERSION and RELEASE_SUBVERSION for `./script/dock pkg` as environment variables.
* Fix an issue when the build script failed when RELEASE_VERSION contained metadata (symbols `-` and `+`, to be specific, like in `3.2.6-12`).

Related issue: https://github.com/percona/orchestrator/issues/36
