### PR TITLE
DISTMYSQL-421: Remove master-slave terminologies in Orchestrator

### DIFF
--- a/docker/Dockerfile.system
+++ b/docker/Dockerfile.system
@@ -19,15 +19,21 @@ RUN git clone -b $ci_env_branch $ci_env_repo # cache
 
 # Setup dbdeployer
 RUN mkdir /dbdeployer
-RUN (cd /dbdeployer && wget https://github.com/datacharmer/dbdeployer/releases/download/v1.64.0/dbdeployer-1.64.0.linux.tar.gz)
-RUN (cd /dbdeployer && tar -xf dbdeployer-1.64.0.linux.tar.gz)
-RUN (cd /dbdeployer && ln -s dbdeployer-1.64.0.linux dbdeployer)
+RUN (cd /dbdeployer && wget https://github.com/datacharmer/dbdeployer/releases/download/v1.73.0/dbdeployer-1.73.0.linux.tar.gz)
+RUN (cd /dbdeployer && tar -xf dbdeployer-1.73.0.linux.tar.gz)
+RUN (cd /dbdeployer && ln -s dbdeployer-1.73.0.linux dbdeployer)
 RUN (cd /dbdeployer && ./dbdeployer defaults update reserved-ports '0')
 RUN (cd /orchestrator/orchestrator-ci-env/bin/linux && ln -s /dbdeployer/dbdeployer)
 
+# Temporary solution:
+# dbdeployer patched to work with PS 8.4
+COPY docker/resources/dbdeployer /dbdeployer/dbdeployer84
+RUN (cd /dbdeployer && ./dbdeployer84 defaults update reserved-ports '0')
+RUN (cd /orchestrator/orchestrator-ci-env/bin/linux && ln -s /dbdeployer/dbdeployer84)
+
 # For dev purposes only, just to avoid downloading over and over via download-mysql script
 # RUN (mkdir /orchestrator/orchestrator-ci-env/mysql-tarballs-downloaded)
-# COPY docker/Percona-Server-8.0.30-22-Linux.x86_64.glibc2.17-minimal.tar.gz /orchestrator/orchestrator-ci-env/mysql-tarballs-downloaded/ 
+# COPY docker/mysql-8.4.0-linux-glibc2.17-x86_64-minimal.tar.xz /orchestrator/orchestrator-ci-env/mysql-tarballs-downloaded/ 
 
 RUN (cd /orchestrator/orchestrator-ci-env && cp bin/linux/systemctl.py /usr/bin/systemctl)
 RUN (cd /orchestrator/orchestrator-ci-env && script/deploy-haproxy)

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -2,7 +2,7 @@ FROM golang:1.20.3-bullseye
 LABEL maintainer="openark@github.com"
 
 RUN apt-get update
-RUN apt-get install -y lsb-release rsync libaio1 numactl sqlite3
+RUN apt-get install -y lsb-release rsync libaio1 numactl sqlite3 libncurses5 libtinfo5
 RUN rm -rf /var/lib/apt/lists/*
 
 ENV WORKPATH /go/src/github.com/openark/orchestrator

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,7 @@ github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab h1:xveKWz2iauee
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=

--- a/go/cmd/orchestrator/main.go
+++ b/go/cmd/orchestrator/main.go
@@ -136,7 +136,7 @@ func main() {
 
 	if len(flag.Args()) == 0 && *command == "" {
 		// No command, no argument: just prompt
-		fmt.Println(app.AppPrompt)
+		fmt.Print(app.AppPrompt)
 		return
 	}
 

--- a/go/db/db.go
+++ b/go/db/db.go
@@ -107,7 +107,7 @@ func openTopology(host string, port int, readTimeout int) (db *sql.DB, err error
 			return nil, err
 		}
 	}
-	sqlUtilsLogger := SqlUtilsLogger{client_context: host + ":" + strconv.Itoa(port)}
+	sqlUtilsLogger := SqlUtilsLogger{client_context: host + ":" + strconv.Itoa(port), backend_connection: false}
 	if db, _, err = sqlutils.GetDB(mysql_uri, sqlUtilsLogger); err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func openOrchestratorMySQLGeneric() (db *sql.DB, fromCache bool, err error) {
 	if config.Config.MySQLOrchestratorUseMutualTLS {
 		uri, _ = SetupMySQLOrchestratorTLS(uri)
 	}
-	sqlUtilsLogger := SqlUtilsLogger{client_context: config.Config.MySQLOrchestratorHost + ":" + strconv.FormatUint(uint64(config.Config.MySQLOrchestratorPort), 10)}
+	sqlUtilsLogger := SqlUtilsLogger{client_context: config.Config.MySQLOrchestratorHost + ":" + strconv.FormatUint(uint64(config.Config.MySQLOrchestratorPort), 10), backend_connection: true}
 	return sqlutils.GetDB(uri, sqlUtilsLogger)
 }
 
@@ -200,7 +200,7 @@ func OpenOrchestrator() (db *sql.DB, err error) {
 			}
 		}
 		dsn := getMySQLURI()
-		sqlUtilsLogger := SqlUtilsLogger{client_context: config.Config.MySQLOrchestratorHost + ":" + strconv.FormatUint(uint64(config.Config.MySQLOrchestratorPort), 10)}
+		sqlUtilsLogger := SqlUtilsLogger{client_context: config.Config.MySQLOrchestratorHost + ":" + strconv.FormatUint(uint64(config.Config.MySQLOrchestratorPort), 10), backend_connection: true}
 		db, fromCache, err = sqlutils.GetDB(dsn, sqlUtilsLogger)
 		if err == nil && !fromCache {
 			log.Debugf("Connected to orchestrator backend: %v", safeMySQLURI(dsn))

--- a/go/db/tls.go
+++ b/go/db/tls.go
@@ -81,19 +81,21 @@ var query_whitelist = []string{
 }
 
 func (logger SqlUtilsLogger) ValidateQuery(query string) {
-	if !logger.backend_connection {
-		// check if whitelisted
-		for i := 0; i < len(query_whitelist); i++ {
-			if strings.Contains(query, query_whitelist[i]) {
-				return
-			}
-		}
+	if logger.backend_connection {
+		return
+	}
 
-		lquery := strings.ToLower(query)
-		if strings.Contains(lquery, "master") || strings.Contains(lquery, "slave") {
-			log.Error("QUERY CONTAINS MASTER / SLAVE: ")
-			// panic("Query contains master/slave: " + query)
+	// check if whitelisted
+	for i := 0; i < len(query_whitelist); i++ {
+		if strings.Contains(query, query_whitelist[i]) {
+			return
 		}
+	}
+
+	lquery := strings.ToLower(query)
+	if strings.Contains(lquery, "master") || strings.Contains(lquery, "slave") {
+		log.Error("QUERY CONTAINS MASTER / SLAVE: ")
+		// panic("Query contains master/slave: " + query)
 	}
 }
 

--- a/go/golib/sqlutils/sqlutils.go
+++ b/go/golib/sqlutils/sqlutils.go
@@ -170,20 +170,35 @@ func (this *RowMap) GetTime(key string) time.Time {
 	return time.Time{}
 }
 
+func validateQuery(query string, db *sql.DB) {
+	// dev purposes only. Remove this return to call query validator function.
+	return
+
+	knownDBsMutex.RLock()
+	defer func() {
+		knownDBsMutex.RUnlock()
+	}()
+	if logger, exists := DB2logger[db]; exists && logger != nil {
+		logger.ValidateQuery((query))
+	}
+}
+
 // knownDBs is a DB cache by uri
 var knownDBs map[string]*sql.DB = make(map[string]*sql.DB)
 var knownDBsMutex = &sync.RWMutex{}
 
 type Logger interface {
 	OnError(context string, query string, err error) error
+	ValidateQuery(query string)
 }
+
 // it is also protected by knownDBsMutex
 var DB2logger map[*sql.DB]Logger = make(map[*sql.DB]Logger)
 
 // GetDB returns a DB instance based on uri.
 // logger parameter is optional. If nil, internal logging will be used.
 // bool result indicates whether the DB was returned from cache; err
-func GetGenericDB(driverName, dataSourceName string ,logger Logger) (*sql.DB, bool, error) {
+func GetGenericDB(driverName, dataSourceName string, logger Logger) (*sql.DB, bool, error) {
 	knownDBsMutex.Lock()
 	defer func() {
 		knownDBsMutex.Unlock()
@@ -221,7 +236,7 @@ func GetSQLiteDB(dbFile string, logger Logger) (*sql.DB, bool, error) {
 func RowToArray(rows *sql.Rows, columns []string) []CellData {
 	buff := make([]interface{}, len(columns))
 	data := make([]CellData, len(columns))
-	for i, _ := range buff {
+	for i := range buff {
 		buff[i] = data[i].NullString()
 	}
 	rows.Scan(buff...)
@@ -265,7 +280,7 @@ func ScanRowsToMaps(rows *sql.Rows, on_row func(RowMap) error) error {
 	return err
 }
 
-func logErrorInternal(context string, db *sql.DB, query string, err error) error{
+func logErrorInternal(context string, db *sql.DB, query string, err error) error {
 	// find logger registered by the client
 	knownDBsMutex.RLock()
 	defer func() {
@@ -282,6 +297,7 @@ func logErrorInternal(context string, db *sql.DB, query string, err error) error
 // QueryRowsMap is a convenience function allowing querying a result set while poviding a callback
 // function activated per read row.
 func QueryRowsMap(db *sql.DB, query string, on_row func(RowMap) error, args ...interface{}) (err error) {
+	validateQuery(query, db)
 	defer func() {
 		if derr := recover(); derr != nil {
 			err = fmt.Errorf("QueryRowsMap unexpected error: %+v", derr)
@@ -302,6 +318,7 @@ func QueryRowsMap(db *sql.DB, query string, on_row func(RowMap) error, args ...i
 
 // queryResultData returns a raw array of rows for a given query, optionally reading and returning column names
 func queryResultData(db *sql.DB, query string, retrieveColumns bool, args ...interface{}) (resultData ResultData, columns []string, err error) {
+	validateQuery(query, db)
 	defer func() {
 		if derr := recover(); derr != nil {
 			err = errors.New(fmt.Sprintf("QueryRowsMap unexpected error: %+v", derr))
@@ -358,6 +375,7 @@ func QueryRowsMapBuffered(db *sql.DB, query string, on_row func(RowMap) error, a
 
 // ExecNoPrepare executes given query using given args on given DB, without using prepared statements.
 func ExecNoPrepare(db *sql.DB, query string, args ...interface{}) (res sql.Result, err error) {
+	validateQuery(query, db)
 	defer func() {
 		if derr := recover(); derr != nil {
 			err = errors.New(fmt.Sprintf("ExecNoPrepare unexpected error: %+v", derr))
@@ -374,6 +392,7 @@ func ExecNoPrepare(db *sql.DB, query string, args ...interface{}) (res sql.Resul
 // ExecQuery executes given query using given args on given DB. It will safele prepare, execute and close
 // the statement.
 func execInternal(silent bool, db *sql.DB, query string, args ...interface{}) (res sql.Result, err error) {
+	validateQuery(query, db)
 	defer func() {
 		if derr := recover(); derr != nil {
 			err = errors.New(fmt.Sprintf("execInternal unexpected error: %+v", derr))

--- a/go/golib/sqlutils/sqlutils.go
+++ b/go/golib/sqlutils/sqlutils.go
@@ -175,9 +175,8 @@ func validateQuery(query string, db *sql.DB) {
 	return
 
 	knownDBsMutex.RLock()
-	defer func() {
-		knownDBsMutex.RUnlock()
-	}()
+	defer knownDBsMutex.RUnlock()
+
 	if logger, exists := DB2logger[db]; exists && logger != nil {
 		logger.ValidateQuery((query))
 	}
@@ -283,9 +282,7 @@ func ScanRowsToMaps(rows *sql.Rows, on_row func(RowMap) error) error {
 func logErrorInternal(context string, db *sql.DB, query string, err error) error {
 	// find logger registered by the client
 	knownDBsMutex.RLock()
-	defer func() {
-		knownDBsMutex.RUnlock()
-	}()
+	defer knownDBsMutex.RUnlock()
 
 	if logger, exists := DB2logger[db]; exists && logger != nil {
 		return logger.OnError(context, query, err)

--- a/go/inst/analysis_dao.go
+++ b/go/inst/analysis_dao.go
@@ -24,7 +24,7 @@ import (
 	"github.com/openark/orchestrator/go/config"
 	"github.com/openark/orchestrator/go/db"
 	"github.com/openark/orchestrator/go/process"
-	"github.com/openark/orchestrator/go/raft"
+	orcraft "github.com/openark/orchestrator/go/raft"
 	"github.com/openark/orchestrator/go/util"
 
 	"github.com/openark/golib/log"

--- a/go/inst/cluster_alias_dao.go
+++ b/go/inst/cluster_alias_dao.go
@@ -206,7 +206,7 @@ func UpdateClusterAliases() error {
 			// MySQL backend (Orchestrator supports only SQLite and MySQL backends)
 			// INSERT ON DUPLICATE KEY UPDATE is more performant than REPLACE in MySQL
 			err = updateClusterAliasesUsingInsert()
-			if (err != nil) {
+			if err != nil {
 				// Fallback to the original, safe implementation
 				err = updateClusterAliasesUsingReplace()
 			}

--- a/go/inst/instance.go
+++ b/go/inst/instance.go
@@ -148,6 +148,9 @@ type Instance struct {
 
 	// Primary of the replication group
 	ReplicationGroupPrimaryInstanceKey InstanceKey
+
+	// Query string provider
+	QSP QueryStringProvider
 }
 
 // NewInstance creates a new, empty instance

--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -1328,7 +1328,7 @@ func ErrantGTIDResetMaster(instanceKey *InstanceKey) (instance *Instance, err er
 		if err != nil {
 			goto Cleanup
 		}
-		replicationStopped, err = waitForReplicationState(instanceKey, ReplicationThreadStateStopped)
+		replicationStopped, err = waitForReplicationState(instance, instanceKey, ReplicationThreadStateStopped)
 		if err != nil {
 			goto Cleanup
 		}
@@ -1358,7 +1358,7 @@ func ErrantGTIDResetMaster(instanceKey *InstanceKey) (instance *Instance, err er
 		goto Cleanup
 	}
 
-	masterStatusFound, executedGtidSet, err = ShowMasterStatus(instanceKey)
+	masterStatusFound, executedGtidSet, err = ShowMasterStatus(instance, instanceKey)
 	if err != nil {
 		err = fmt.Errorf("gtid-errant-reset-master: error getting master status on %+v, after which intended to set gtid_purged to: %s. Error was: %+v", instance.Key, gtidSubtract, err)
 		goto Cleanup

--- a/go/inst/query_string_provider.go
+++ b/go/inst/query_string_provider.go
@@ -1,0 +1,351 @@
+package inst
+
+import "strings"
+
+type QueryStringKey int
+
+type QueryStringProvider struct {
+	queries map[QueryStringKey]string
+}
+
+const (
+	log_slave_updates QueryStringKey = iota
+	start_slave
+	show_slave_status
+	slave_io_running
+	slave_sql_running
+	show_master_status
+	master_gtid_info
+	master_user
+	slave_io_state
+	master_log_file
+	read_master_log_pos
+	relay_master_log_file
+	relay_master_log_position
+	master_uuid
+	master_host
+	master_port
+	seconds_behind_master
+	master_ssl_allowed
+	show_slave_hosts
+
+	stop_slave_io_thread
+	stop_slave_sql_thread
+	start_slave_sql_thread
+	start_slave_io_thread
+	stop_slave
+	start_slave_until_master_log
+	master_user_param
+	master_password_param
+	master_ssl_ca_param
+	master_ssl_cert_param
+	master_ssl
+	master_ssl_key_param
+	change_master_to_master_ssl
+	reset_slave
+	change_master_to_master_host_port
+	change_master_to_master_host_port_log_gtid_no
+	change_master_to_master_host_port_log_autoposition_no
+	change_master_to_master_host_port_autoposition_yes
+	change_master_to_master_host_port_log
+	change_master_to_master_host
+	reset_slave_50603_all
+	reset_master
+	select_master_pos_wait
+	change_master_to_with_params
+	change_master_to_master_delay
+	set_sql_slave_skip_counter
+)
+
+func (qps *QueryStringProvider) log_slave_updates() string {
+	return qps.queries[log_slave_updates]
+}
+
+func (qps *QueryStringProvider) start_slave() string {
+	return qps.queries[start_slave]
+}
+
+func (qps *QueryStringProvider) show_slave_status() string {
+	return qps.queries[show_slave_status]
+}
+
+func (qps *QueryStringProvider) slave_io_running() string {
+	return qps.queries[slave_io_running]
+}
+
+func (qps *QueryStringProvider) slave_sql_running() string {
+	return qps.queries[slave_sql_running]
+}
+
+func (qps *QueryStringProvider) master_gtid_info() string {
+	return qps.queries[master_gtid_info]
+}
+
+func (qps *QueryStringProvider) show_master_status() string {
+	return qps.queries[show_master_status]
+}
+
+func (qps *QueryStringProvider) master_user() string {
+	return qps.queries[master_user]
+}
+
+func (qps *QueryStringProvider) slave_io_state() string {
+	return qps.queries[slave_io_state]
+}
+
+func (qps *QueryStringProvider) master_log_file() string {
+	return qps.queries[master_log_file]
+}
+
+func (qps *QueryStringProvider) read_master_log_pos() string {
+	return qps.queries[read_master_log_pos]
+}
+
+func (qps *QueryStringProvider) relay_master_log_file() string {
+	return qps.queries[relay_master_log_file]
+}
+
+func (qps *QueryStringProvider) relay_master_log_position() string {
+	return qps.queries[relay_master_log_position]
+}
+
+func (qps *QueryStringProvider) master_uuid() string {
+	return qps.queries[master_uuid]
+}
+
+func (qps *QueryStringProvider) master_host() string {
+	return qps.queries[master_host]
+}
+
+func (qps *QueryStringProvider) master_port() string {
+	return qps.queries[master_port]
+}
+
+func (qps *QueryStringProvider) seconds_behind_master() string {
+	return qps.queries[seconds_behind_master]
+}
+
+func (qps *QueryStringProvider) master_ssl_allowed() string {
+	return qps.queries[master_ssl_allowed]
+}
+
+func (qps *QueryStringProvider) show_slave_hosts() string {
+	return qps.queries[show_slave_hosts]
+}
+
+func (qps *QueryStringProvider) stop_slave_io_thread() string {
+	return qps.queries[stop_slave_io_thread]
+}
+
+func (qps *QueryStringProvider) stop_slave_sql_thread() string {
+	return qps.queries[stop_slave_sql_thread]
+}
+
+func (qps *QueryStringProvider) start_slave_sql_thread() string {
+	return qps.queries[start_slave_sql_thread]
+}
+
+func (qps *QueryStringProvider) start_slave_io_thread() string {
+	return qps.queries[start_slave_io_thread]
+}
+
+func (qps *QueryStringProvider) stop_slave() string {
+	return qps.queries[stop_slave]
+}
+
+func (qps *QueryStringProvider) start_slave_until_master_log() string {
+	return qps.queries[start_slave_until_master_log]
+}
+
+func (qps *QueryStringProvider) master_user_param() string {
+	return qps.queries[master_user_param]
+}
+
+func (qps *QueryStringProvider) master_password_param() string {
+	return qps.queries[master_password_param]
+}
+
+func (qps *QueryStringProvider) master_ssl_ca_param() string {
+	return qps.queries[master_ssl_ca_param]
+}
+
+func (qps *QueryStringProvider) master_ssl_cert_param() string {
+	return qps.queries[master_ssl_cert_param]
+}
+
+func (qps *QueryStringProvider) master_ssl() string {
+	return qps.queries[master_ssl]
+}
+
+func (qps *QueryStringProvider) master_ssl_key_param() string {
+	return qps.queries[master_ssl_key_param]
+}
+
+func (qps *QueryStringProvider) change_master_to_master_ssl() string {
+	return qps.queries[change_master_to_master_ssl]
+}
+
+func (qps *QueryStringProvider) reset_slave() string {
+	return qps.queries[reset_slave]
+}
+
+func (qps *QueryStringProvider) change_master_to_master_host_port() string {
+	return qps.queries[change_master_to_master_host_port]
+}
+
+func (qps *QueryStringProvider) change_master_to_master_host_port_log_gtid_no() string {
+	return qps.queries[change_master_to_master_host_port_log_gtid_no]
+}
+
+func (qps *QueryStringProvider) change_master_to_master_host_port_log_autoposition_no() string {
+	return qps.queries[change_master_to_master_host_port_log_autoposition_no]
+}
+
+func (qps *QueryStringProvider) change_master_to_master_host_port_autoposition_yes() string {
+	return qps.queries[change_master_to_master_host_port_autoposition_yes]
+}
+
+func (qps *QueryStringProvider) change_master_to_master_host_port_log() string {
+	return qps.queries[change_master_to_master_host_port_log]
+}
+
+func (qps *QueryStringProvider) change_master_to_master_host() string {
+	return qps.queries[change_master_to_master_host]
+}
+
+func (qps *QueryStringProvider) reset_slave_50603_all() string {
+	return qps.queries[reset_slave_50603_all]
+}
+
+func (qps *QueryStringProvider) reset_master() string {
+	return qps.queries[reset_master]
+}
+
+func (qps *QueryStringProvider) select_master_pos_wait() string {
+	return qps.queries[select_master_pos_wait]
+}
+
+func (qps *QueryStringProvider) change_master_to_with_params() string {
+	return qps.queries[change_master_to_with_params]
+}
+
+func (qps *QueryStringProvider) change_master_to_master_delay() string {
+	return qps.queries[change_master_to_master_delay]
+}
+
+func (qps *QueryStringProvider) set_sql_slave_skip_counter() string {
+	return qps.queries[set_sql_slave_skip_counter]
+}
+
+var queryStrings80 = map[QueryStringKey]string{
+	log_slave_updates:         "log_slave_updates",
+	start_slave:               "start slave",
+	show_slave_status:         "show slave status",
+	slave_io_running:          "Slave_IO_Running",
+	slave_sql_running:         "Slave_SQL_Running",
+	show_master_status:        "show master status",
+	master_gtid_info:          "select @@global.gtid_mode, @@global.server_uuid, @@global.gtid_executed, @@global.gtid_purged, @@global.master_info_repository = 'TABLE', @@global.binlog_row_image",
+	master_user:               "Master_User",
+	slave_io_state:            "Slave_IO_State",
+	master_log_file:           "Master_Log_File",
+	read_master_log_pos:       "Read_Master_Log_Pos",
+	relay_master_log_file:     "Relay_Master_Log_File",
+	relay_master_log_position: "Exec_Master_Log_Pos",
+	master_uuid:               "Master_UUID",
+	master_host:               "Master_Host",
+	master_port:               "Master_Port",
+	seconds_behind_master:     "Seconds_Behind_Master",
+	master_ssl_allowed:        "Master_SSL_Allowed",
+	show_slave_hosts:          "show slave hosts",
+
+	stop_slave_io_thread:                          "stop slave io_thread",
+	stop_slave_sql_thread:                         "stop slave sql_thread",
+	start_slave_sql_thread:                        "start slave sql_thread",
+	start_slave_io_thread:                         "start slave io_thread",
+	stop_slave:                                    "stop slave",
+	start_slave_until_master_log:                  "start slave until master_log_file=?, master_log_pos=?",
+	master_user_param:                             "master_user = ?",
+	master_password_param:                         "master_password = ?",
+	master_ssl_ca_param:                           "master_ssl_ca = ?",
+	master_ssl_cert_param:                         "master_ssl_cert = ?",
+	master_ssl:                                    "master_ssl",
+	master_ssl_key_param:                          "master_ssl_key = ?",
+	change_master_to_master_ssl:                   "change master to master_ssl=1",
+	reset_slave:                                   "reset slave",
+	change_master_to_master_host_port:             "change master to master_host=?, master_port=?",
+	change_master_to_master_host_port_log_gtid_no: "change master to master_host=?, master_port=?, master_log_file=?, master_log_pos=?, master_use_gtid=no",
+	change_master_to_master_host_port_log_autoposition_no: "change master to master_host=?, master_port=?, master_log_file=?, master_log_pos=?, master_auto_position=0",
+	change_master_to_master_host_port_autoposition_yes:    "change master to master_host=?, master_port=?, master_auto_position=1",
+	change_master_to_master_host_port_log:                 "change master to master_host=?, master_port=?, master_log_file=?, master_log_pos=?",
+	change_master_to_master_host:                          "change master to master_host='_'",
+	reset_slave_50603_all:                                 "reset slave /*!50603 all */",
+	reset_master:                                          "reset master",
+	select_master_pos_wait:                                "select master_pos_wait(?, ?)",
+	change_master_to_with_params:                          "change master to %s",
+	change_master_to_master_delay:                         "change master to master_delay=%d",
+	set_sql_slave_skip_counter:                            "set global sql_slave_skip_counter := 1",
+}
+
+var queryStrings84 = map[QueryStringKey]string{
+	log_slave_updates:         "log_replica_updates",
+	start_slave:               "start replica",
+	show_slave_status:         "show replica status",
+	slave_io_running:          "Replica_IO_Running",
+	slave_sql_running:         "Replica_SQL_Running",
+	show_master_status:        "show binary log status",
+	master_gtid_info:          "select @@global.gtid_mode, @@global.server_uuid, @@global.gtid_executed, @@global.gtid_purged, 1, @@global.binlog_row_image",
+	master_user:               "Source_User",
+	slave_io_state:            "Replica_IO_State",
+	master_log_file:           "Source_Log_File",
+	read_master_log_pos:       "Read_Source_Log_Pos",
+	relay_master_log_file:     "Relay_Source_Log_File",
+	relay_master_log_position: "Exec_Source_Log_Pos",
+	master_uuid:               "Source_UUID",
+	master_host:               "Source_Host",
+	master_port:               "Source_Port",
+	seconds_behind_master:     "Seconds_Behind_Source",
+	master_ssl_allowed:        "Source_SSL_Allowed",
+	show_slave_hosts:          "show replicas",
+
+	stop_slave_io_thread:                          "stop replica io_thread",
+	stop_slave_sql_thread:                         "stop replica sql_thread",
+	start_slave_sql_thread:                        "start replica sql_thread",
+	start_slave_io_thread:                         "start replica io_thread",
+	stop_slave:                                    "stop replica",
+	start_slave_until_master_log:                  "start replica until source_log_file=?, source_log_pos=?",
+	master_user_param:                             "source_user = ?",
+	master_password_param:                         "source_password = ?",
+	master_ssl_ca_param:                           "source_ssl_ca = ?",
+	master_ssl_cert_param:                         "source_ssl_cert = ?",
+	master_ssl:                                    "source_ssl",
+	master_ssl_key_param:                          "source_ssl_key = ?",
+	change_master_to_master_ssl:                   "change replication source to source_ssl=1",
+	reset_slave:                                   "reset replica",
+	change_master_to_master_host_port:             "change replication source to source_host=?, source_port=?",
+	change_master_to_master_host_port_log_gtid_no: "change replication source to source_host=?, source_port=?, source_log_file=?, source_log_pos=?, source_use_gtid=no",
+	change_master_to_master_host_port_log_autoposition_no: "change replication source to source_host=?, source_port=?, source_log_file=?, source_log_pos=?, source_auto_position=0",
+	change_master_to_master_host_port_autoposition_yes:    "change replication source to source_host=?, source_port=?, source_auto_position=1",
+	change_master_to_master_host_port_log:                 "change replication source to source_host=?, source_port=?, source_log_file=?, source_log_pos=?",
+	change_master_to_master_host:                          "change replication source to source_host='_'",
+	reset_slave_50603_all:                                 "reset replica /*!50603 all */",
+	reset_master:                                          "reset binary logs and gtids",
+	select_master_pos_wait:                                "select source_pos_wait(?, ?)",
+	change_master_to_with_params:                          "change replication source to %s",
+	change_master_to_master_delay:                         "change replication source to source_delay=%d",
+	set_sql_slave_skip_counter:                            "set global sql_replica_skip_counter := 1",
+}
+
+var queryStringProvider80 = QueryStringProvider{
+	queries: queryStrings80,
+}
+
+var queryStringProvider84 = QueryStringProvider{
+	queries: queryStrings84,
+}
+
+func GetQueryStringProvider(version string) QueryStringProvider {
+	if strings.HasPrefix(version, "8.4") {
+		return queryStringProvider84
+	}
+	return queryStringProvider80
+}

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -1642,7 +1642,7 @@ func emergentlyRestartReplicationOnTopologyInstance(instanceKey *inst.InstanceKe
 			return
 		}
 
-		inst.RestartReplicationQuick(instanceKey)
+		inst.RestartReplicationQuick(instance, instanceKey)
 		inst.AuditOperation("emergently-restart-replication-topology-instance", instanceKey, string(analysisCode))
 	})
 }

--- a/run/test-integration.sh
+++ b/run/test-integration.sh
@@ -7,7 +7,7 @@ export CI_ENV_REPO=
 export CI_ENV_BRANCH=
 
 # Configure test run parameters
-export TARBALL_URL=https://downloads.percona.com/downloads/Percona-Server-8.0/Percona-Server-8.0.26-16/binary/tarball/Percona-Server-8.0.26-16-Linux.x86_64.glibc2.12-minimal.tar.gz
+export TARBALL_URL=https://dev.mysql.com/get/Downloads/MySQL-8.4/mysql-8.4.0-linux-glibc2.17-x86_64-minimal.tar.xz
 export RUN_TESTS=YES
 export ALLOW_TESTS_FAILURES=YES
 

--- a/run/test-system.sh
+++ b/run/test-system.sh
@@ -7,7 +7,11 @@ export CI_ENV_REPO=
 export CI_ENV_BRANCH=
 
 # Configure test run parameters
-export TARBALL_URL=https://downloads.percona.com/downloads/Percona-Server-8.0/Percona-Server-8.0.30-22/binary/tarball/Percona-Server-8.0.30-22-Linux.x86_64.glibc2.17-minimal.tar.gz
+export TARBALL_URL=https://dev.mysql.com/get/Downloads/MySQL-8.4/mysql-8.4.0-linux-glibc2.17-x86_64-minimal.tar.xz
+# export TARBALL_URL=https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.37-linux-glibc2.17-x86_64-minimal.tar.xz
+
+#export TARBALL_URL=https://downloads.percona.com/downloads/Percona-Server-8.0/Percona-Server-8.0.36-28/binary/tarball/Percona-Server-8.0.36-28-Linux.x86_64.glibc2.17-minimal.tar.gz
+
 export RUN_TESTS=YES
 export ALLOW_TESTS_FAILURES=YES
 

--- a/tests/system/test.sh
+++ b/tests/system/test.sh
@@ -306,7 +306,7 @@ test_all() {
   local failed_cnt=0
   local total_cnt=0
   local expected_cnt=`find $tests_path -mindepth 1 -maxdepth 1 ! -path . -type d | wc -l`
-  
+
   local test_pattern="${1:-.}"
 
   echo "." > $tests_todo_file
@@ -318,7 +318,7 @@ test_all() {
       fi
       if should_attempt_test "$test_name" "$test_pattern" ; then
         # try up to 3 times. Some tests seem to be not stable
-        
+
         test_status="PASSED"
         for i in {1..3}
         do
@@ -359,7 +359,7 @@ test_all() {
         else
           echo "Unexpected test_status: ${test_status}"
         fi
-        ((total_cnt++))    
+        ((total_cnt++))
       else
         : # echo "# should not attempt $test_name"
       fi
@@ -371,8 +371,8 @@ test_all() {
       exit 1
     fi
   done || exit 1
-  
-  echo "Test results:"
+
+  echo "Test results (cnt/executed_tests_cnt/total_tests_count):"
   echo "PASSED:   ${passed_cnt}/${total_cnt}/${expected_cnt}"
   echo "UNSTABLE: ${unstable_cnt}/${total_cnt}/${expected_cnt}"
   echo "FAILED:   ${failed_cnt}/${total_cnt}/${expected_cnt}"

--- a/vendor/github.com/openark/golib/sqlutils/sqlutils.go
+++ b/vendor/github.com/openark/golib/sqlutils/sqlutils.go
@@ -175,9 +175,8 @@ func validateQuery(query string, db *sql.DB) {
 	return
 
 	knownDBsMutex.RLock()
-	defer func() {
-		knownDBsMutex.RUnlock()
-	}()
+	defer knownDBsMutex.RUnlock()
+
 	if logger, exists := DB2logger[db]; exists && logger != nil {
 		logger.ValidateQuery((query))
 	}
@@ -282,9 +281,7 @@ func ScanRowsToMaps(rows *sql.Rows, on_row func(RowMap) error) error {
 func logErrorInternal(context string, db *sql.DB, query string, err error) error{
 	// find logger registered by the client
 	knownDBsMutex.RLock()
-	defer func() {
-		knownDBsMutex.RUnlock()
-	}()
+	defer knownDBsMutex.RUnlock()
 
 	if logger, exists := DB2logger[db]; exists && logger != nil {
 		return logger.OnError(context, query, err)


### PR DESCRIPTION
1. Orchestrator calls intercepted by QueryStringProvider
2. Test framework adjusted to be able to use 8.4

Temporary solution:
Hacked dbdeployer added (out of the box it doesn't work with 8.4)