### PR TITLE
DISTMYSQL 412: Orchestrator should handle tagged GTIDs

### DIFF
--- a/go/inst/oracle_gtid_set_entry.go
+++ b/go/inst/oracle_gtid_set_entry.go
@@ -28,47 +28,250 @@ var (
 	multiValueInterval  = regexp.MustCompile("^([0-9]+)[-]([0-9]+)$")
 )
 
+type TagInterval struct {
+	Tag      string   // tag name
+	Interval []string // intervals
+}
+
 // OracleGtidSetEntry represents an entry in a set of GTID ranges,
-// for example, the entry: "316d193c-70e5-11e5-adb2-ecf4bb2262ff:1-8935:8984-6124596" (may include gaps)
+// for example,
+//
+//	Valid Formats:
+//		- "316d193c-70e5-11e5-adb2-ecf4bb2262ff:1-8935:8984-6124596" (may include gaps)
+//		- "321f5c0d-70e5-11e5-adb2-ecf4bb2262ff:1-56457" (no gaps)
+//		- "230ea8ea-81e3-11e4-972a-e25ec4bd140a:1-10539:tag1:1-2474" (tagged intervals)
+//		- "230ea8ea-81e3-11e4-972a-e25ec4bd140a:1-5139:5780-6317:tag1:1-2474:3201-4157" (tagged intervals and may have gaps)
 type OracleGtidSetEntry struct {
-	UUID   string
-	Ranges string
+	UUID      string
+	DefaultIv string        // default (untagged) interval
+	TaggedIv  []TagInterval // tagged intervals
+}
+
+func ParseOracleGtidSetEntry(gtidRangeString string) (*OracleGtidSetEntry, error) {
+
+	// Split the string into two parts: UUID part and the non-UUID part
+	gtid_str := strings.SplitN(gtidRangeString, ":", 2)
+
+	// Sanity check
+	if len(gtid_str) != 2 {
+		return nil, fmt.Errorf("Cannot parse OracleGtidSetEntry from %s", gtidRangeString)
+	}
+
+	first_part := gtid_str[0]
+	second_part := gtid_str[1]
+
+	if first_part == "" {
+		return nil, fmt.Errorf("Unexpected UUID: %s", first_part)
+	}
+
+	if second_part == "" {
+		return nil, fmt.Errorf("Unexpected GTID range: %s", second_part)
+	}
+
+	// UUID is the first part
+	uuid := first_part
+
+	// Split the non-UUID parts into multiple blocks
+	s := strings.SplitN(second_part, ":", -1)
+
+	var auto_iv string        // default interval
+	var tag string            // any tag
+	var iv []string           // any interval
+	var tag_ivs []TagInterval // Full tagged interval
+
+	// Regex Patterns to match tag and interval s
+	re_tag := regexp.MustCompile("^[a-z_][a-z0-9_]") // tag must start with a letter
+
+	for i := range s {
+
+		// If it is a GTID tag
+		if re_tag.MatchString(s[i]) {
+
+			// Finalize previous tag before processing new tag
+			if len(tag) != 0 {
+
+				if len(iv) == 0 {
+					return nil, fmt.Errorf("Invalid format: Found a tag without any intervals")
+				}
+
+				var ti TagInterval
+				ti.Tag = tag
+				ti.Interval = iv
+
+				tag_ivs = append(tag_ivs, ti)
+			}
+
+			// Reset iv for next tag
+			iv = nil
+
+			// Now process the new tag
+			tag = s[i]
+
+		} else {
+
+			// If it is an GTID interval
+			if singleValueInterval.MatchString(s[i]) || multiValueInterval.MatchString(s[i]) {
+
+				// If it is an empty tag, add it to default interval
+				if len(tag) == 0 {
+					auto_iv += ":" + s[i]
+				} else {
+					// If tag is mentioned
+					iv = append(iv, s[i])
+				}
+
+			} else {
+				return nil, fmt.Errorf("Invalid format")
+			}
+		}
+	}
+
+	// Finalize the last tag
+	if len(tag) != 0 {
+
+		// If there are no intervals for the last tag
+		if len(iv) == 0 {
+			return nil, fmt.Errorf("Invalid format: Found a tag without any intervals")
+		}
+
+		// Create a new tag interval and append it to the list
+		var ti TagInterval
+		ti.Tag = tag
+		ti.Interval = iv
+		tag_ivs = append(tag_ivs, ti)
+	}
+
+	// Don't append ':' for the first interval in the default set
+	if len(auto_iv) != 0 {
+		after, _ := strings.CutPrefix(auto_iv, ":")
+		auto_iv = after
+	}
+
+	entry := OracleGtidSetEntry{UUID: uuid, DefaultIv: auto_iv, TaggedIv: tag_ivs}
+
+	return &entry, nil
 }
 
 // NewOracleGtidSetEntry parses a single entry text
 func NewOracleGtidSetEntry(gtidRangeString string) (*OracleGtidSetEntry, error) {
 	gtidRangeString = strings.TrimSpace(gtidRangeString)
-	tokens := strings.SplitN(gtidRangeString, ":", 2)
-	if len(tokens) != 2 {
-		return nil, fmt.Errorf("Cannot parse OracleGtidSetEntry from %s", gtidRangeString)
+
+	gtidRange, error := ParseOracleGtidSetEntry(gtidRangeString)
+	if gtidRange == nil {
+		return nil, error
 	}
-	if tokens[0] == "" {
-		return nil, fmt.Errorf("Unexpected UUID: %s", tokens[0])
-	}
-	if tokens[1] == "" {
-		return nil, fmt.Errorf("Unexpected GTID range: %s", tokens[1])
-	}
-	gtidRange := &OracleGtidSetEntry{UUID: tokens[0], Ranges: tokens[1]}
+
 	return gtidRange, nil
 }
 
 // String returns a user-friendly string representation of this entry
 func (this *OracleGtidSetEntry) String() string {
-	return fmt.Sprintf("%s:%s", this.UUID, this.Ranges)
+
+	var res string
+
+	// UUID is always added in the beginning of the Gtid_set
+	res += this.UUID
+
+	// Default ranges are always added immediately after the UUID
+	if len(this.DefaultIv) != 0 {
+		res += ":" + this.DefaultIv
+	}
+
+	// Tagged ranges are added in the end of the Gtid_set
+	for _, v := range this.TaggedIv {
+		res += ":" + v.Tag
+		for _, iv := range v.Interval {
+			res += ":" + iv
+		}
+	}
+	return res
 }
 
-// String returns a user-friendly string representation of this entry
+/*
+String returns a user-friendly individual string representation of the gtid set
+
+Example:
+Explode of the GTID set "48ebed33-0d12-11ef-a3ec-ac198e4551c8:1-3:7:tag1:1-2:10-12:tag2:74-75:78:81"
+shall return the following
+
+48ebed33-0d12-11ef-a3ec-ac198e4551c8:1
+48ebed33-0d12-11ef-a3ec-ac198e4551c8:2
+48ebed33-0d12-11ef-a3ec-ac198e4551c8:3
+48ebed33-0d12-11ef-a3ec-ac198e4551c8:7
+48ebed33-0d12-11ef-a3ec-ac198e4551c8:tag1:1
+48ebed33-0d12-11ef-a3ec-ac198e4551c8:tag1:2
+48ebed33-0d12-11ef-a3ec-ac198e4551c8:tag1:10
+48ebed33-0d12-11ef-a3ec-ac198e4551c8:tag1:11
+48ebed33-0d12-11ef-a3ec-ac198e4551c8:tag1:12
+48ebed33-0d12-11ef-a3ec-ac198e4551c8:tag2:74
+48ebed33-0d12-11ef-a3ec-ac198e4551c8:tag2:75
+48ebed33-0d12-11ef-a3ec-ac198e4551c8:tag2:78
+48ebed33-0d12-11ef-a3ec-ac198e4551c8:tag2:81
+*/
 func (this *OracleGtidSetEntry) Explode() (result [](*OracleGtidSetEntry)) {
-	intervals := strings.Split(this.Ranges, ":")
-	for _, interval := range intervals {
-		if submatch := multiValueInterval.FindStringSubmatch(interval); submatch != nil {
-			intervalStart, _ := strconv.Atoi(submatch[1])
-			intervalEnd, _ := strconv.Atoi(submatch[2])
-			for i := intervalStart; i <= intervalEnd; i++ {
-				result = append(result, &OracleGtidSetEntry{UUID: this.UUID, Ranges: fmt.Sprintf("%d", i)})
+
+	// Appends the default interval to the result
+	var AppendDefaultInterval = func(this *OracleGtidSetEntry) {
+		intervals := strings.Split(this.DefaultIv, ":")
+		for _, interval := range intervals {
+			// Multi-value interval
+			if submatch := multiValueInterval.FindStringSubmatch(interval); submatch != nil {
+				intervalStart, _ := strconv.Atoi(submatch[1])
+				intervalEnd, _ := strconv.Atoi(submatch[2])
+				for i := intervalStart; i <= intervalEnd; i++ {
+					result = append(result, &OracleGtidSetEntry{UUID: this.UUID, DefaultIv: fmt.Sprintf("%d", i)})
+				}
+			} else if submatch := singleValueInterval.FindStringSubmatch(interval); submatch != nil {
+				// Single-value interval
+				result = append(result, &OracleGtidSetEntry{UUID: this.UUID, DefaultIv: interval})
 			}
-		} else if submatch := singleValueInterval.FindStringSubmatch(interval); submatch != nil {
-			result = append(result, &OracleGtidSetEntry{UUID: this.UUID, Ranges: interval})
+		}
+	}
+
+	// Appends tagged intervals to the result
+	var AppendTaggedInterval = func(tag *string, interval string) {
+
+		intervals := strings.Split(interval, ":")
+		for _, interval := range intervals {
+
+			// Multi-value interval
+			if submatch := multiValueInterval.FindStringSubmatch(interval); submatch != nil {
+
+				intervalStart, _ := strconv.Atoi(submatch[1])
+				intervalEnd, _ := strconv.Atoi(submatch[2])
+				for i := intervalStart; i <= intervalEnd; i++ {
+					var ti TagInterval
+					ti.Tag = *tag
+					ti.Interval = append(ti.Interval, fmt.Sprintf("%d", i))
+
+					var taggedIv []TagInterval
+					taggedIv = append(taggedIv, ti)
+
+					entry := OracleGtidSetEntry{UUID: this.UUID, TaggedIv: taggedIv}
+					result = append(result, &entry)
+				}
+			} else if submatch := singleValueInterval.FindStringSubmatch(interval); submatch != nil {
+				// Single-value interval
+				var ti TagInterval
+				ti.Tag = *tag
+				ti.Interval = append(ti.Interval, interval)
+
+				var taggedIv []TagInterval
+				taggedIv = append(taggedIv, ti)
+
+				entry := OracleGtidSetEntry{UUID: this.UUID, TaggedIv: taggedIv}
+				result = append(result, &entry)
+			}
+		}
+	}
+
+	// Process default interval first
+	AppendDefaultInterval(this)
+
+	// Process tagged intervals next
+	for _, v := range this.TaggedIv {
+		for _, iv := range v.Interval {
+			AppendTaggedInterval(&v.Tag, iv)
 		}
 	}
 	return result

--- a/go/inst/oracle_gtid_set_test.go
+++ b/go/inst/oracle_gtid_set_test.go
@@ -12,20 +12,133 @@ func TestNewOracleGtidSetEntry(t *testing.T) {
 		entry, err := NewOracleGtidSetEntry(uuidSet)
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(entry.UUID, "00020194-3333-3333-3333-333333333333")
-		test.S(t).ExpectEquals(entry.Ranges, "1-7")
+		test.S(t).ExpectEquals(entry.DefaultIv, "1-7")
 	}
 	{
 		uuidSet := "00020194-3333-3333-3333-333333333333:1-7:10-20"
 		entry, err := NewOracleGtidSetEntry(uuidSet)
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(entry.UUID, "00020194-3333-3333-3333-333333333333")
-		test.S(t).ExpectEquals(entry.Ranges, "1-7:10-20")
+		test.S(t).ExpectEquals(entry.DefaultIv, "1-7:10-20")
 	}
 	{
 		uuidSet := "00020194-3333-3333-3333-333333333333"
 		_, err := NewOracleGtidSetEntry(uuidSet)
 		test.S(t).ExpectNotNil(err)
 	}
+
+	// Negative tests for tagged gtids
+	{
+		// Empty tag name
+		uuidSet := "00020194-3333-3333-3333-333333333333:1-7:10-20:"
+		_, err := NewOracleGtidSetEntry(uuidSet)
+		test.S(t).ExpectNotNil(err)
+	}
+	{
+		// Invalid tag name
+		uuidSet := "00020194-3333-3333-3333-333333333333:1-7:10-20:123tag1:1"
+		_, err := NewOracleGtidSetEntry(uuidSet)
+		test.S(t).ExpectNotNil(err)
+	}
+	{
+		// Valid tag name but no interval after tag name
+		uuidSet := "00020194-3333-3333-3333-333333333333:1-7:10-20:tag1"
+		_, err := NewOracleGtidSetEntry(uuidSet)
+		test.S(t).ExpectNotNil(err)
+	}
+	{
+		// Valid tag name but empty interval after tag name
+		uuidSet := "00020194-3333-3333-3333-333333333333:tag1:"
+		_, err := NewOracleGtidSetEntry(uuidSet)
+		test.S(t).ExpectNotNil(err)
+	}
+	{
+		// Valid tag name but invalid interval after tag name
+		uuidSet := "00020194-3333-3333-3333-333333333333:tag1:random"
+		_, err := NewOracleGtidSetEntry(uuidSet)
+		test.S(t).ExpectNotNil(err)
+	}
+
+	// Positive tests for tagged gtids
+	{
+		// Single valued tagged interval
+		uuidSet := "00020194-3333-3333-3333-333333333333:1-7:10-20:tag1:1"
+		entry, err := NewOracleGtidSetEntry(uuidSet)
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(entry.UUID, "00020194-3333-3333-3333-333333333333")
+		test.S(t).ExpectEquals(entry.DefaultIv, "1-7:10-20")
+
+		// There is only one tagged interval
+		test.S(t).ExpectEquals(len(entry.TaggedIv), 1)
+
+		// There is only tagged interval range
+		test.S(t).ExpectEquals(len(entry.TaggedIv[0].Interval), 1)
+
+		test.S(t).ExpectEquals(entry.TaggedIv[0].Tag, "tag1")
+		test.S(t).ExpectEquals(entry.TaggedIv[0].Interval[0], "1")
+	}
+	{
+		// Multi valued tagged interval
+		uuidSet := "00020194-3333-3333-3333-333333333333:1-7:10-20:tag1:1-56"
+		entry, err := NewOracleGtidSetEntry(uuidSet)
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(entry.UUID, "00020194-3333-3333-3333-333333333333")
+		test.S(t).ExpectEquals(entry.DefaultIv, "1-7:10-20")
+
+		// There is only one tagged interval
+		test.S(t).ExpectEquals(len(entry.TaggedIv), 1)
+
+		// There are only tagged interval range
+		test.S(t).ExpectEquals(len(entry.TaggedIv[0].Interval), 1)
+
+		test.S(t).ExpectEquals(entry.TaggedIv[0].Tag, "tag1")
+		test.S(t).ExpectEquals(entry.TaggedIv[0].Interval[0], "1-56")
+	}
+	{
+		// No default interval
+		uuidSet := "00020194-3333-3333-3333-333333333333:domain.com:1:51-56"
+		entry, err := NewOracleGtidSetEntry(uuidSet)
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(entry.UUID, "00020194-3333-3333-3333-333333333333")
+		test.S(t).ExpectEquals(entry.DefaultIv, "")
+
+		// There is only one tagged interval
+		test.S(t).ExpectEquals(len(entry.TaggedIv), 1)
+
+		// There are two tagged interval ranges
+		test.S(t).ExpectEquals(len(entry.TaggedIv[0].Interval), 2)
+
+		test.S(t).ExpectEquals(entry.TaggedIv[0].Tag, "domain.com")
+		test.S(t).ExpectEquals(entry.TaggedIv[0].Interval[0], "1")
+		test.S(t).ExpectEquals(entry.TaggedIv[0].Interval[1], "51-56")
+	}
+	{
+		// No default interval, multiple tagged intervals
+		uuidSet := "00020194-3333-3333-3333-333333333333:domain1.com:1:51-56:domain2.com:1-78:151-256:514"
+		entry, err := NewOracleGtidSetEntry(uuidSet)
+		test.S(t).ExpectNil(err)
+		test.S(t).ExpectEquals(entry.UUID, "00020194-3333-3333-3333-333333333333")
+		test.S(t).ExpectEquals(entry.DefaultIv, "")
+
+		// There are two tagged intervals
+		test.S(t).ExpectEquals(len(entry.TaggedIv), 2)
+
+		// tag 1 (domain1.com) has two interval ranges
+		test.S(t).ExpectEquals(len(entry.TaggedIv[0].Interval), 2)
+
+		test.S(t).ExpectEquals(entry.TaggedIv[0].Tag, "domain1.com")
+		test.S(t).ExpectEquals(entry.TaggedIv[0].Interval[0], "1")
+		test.S(t).ExpectEquals(entry.TaggedIv[0].Interval[1], "51-56")
+
+		// tag 2 (domain2.com) has three interval ranges
+		test.S(t).ExpectEquals(len(entry.TaggedIv[1].Interval), 3)
+
+		test.S(t).ExpectEquals(entry.TaggedIv[1].Tag, "domain2.com")
+		test.S(t).ExpectEquals(entry.TaggedIv[1].Interval[0], "1-78")
+		test.S(t).ExpectEquals(entry.TaggedIv[1].Interval[1], "151-256")
+		test.S(t).ExpectEquals(entry.TaggedIv[1].Interval[2], "514")
+	}
+
 }
 
 func TestExplode(t *testing.T) {
@@ -74,9 +187,75 @@ func TestExplode(t *testing.T) {
 		test.S(t).ExpectEquals(exploded[2].String(), "00020194-3333-3333-3333-333333333333:7")
 		test.S(t).ExpectEquals(exploded[3].String(), "00020194-3333-3333-3333-333333333333:8")
 	}
+
+	// Explode tests for tagged GTIDS
+	{
+		// Single valued tagged gtid with default interval
+		gtidSetVal := "00020192-1111-1111-1111-111111111111:29-30:tag1:1"
+		gtidSet, err := NewOracleGtidSet(gtidSetVal)
+		test.S(t).ExpectNil(err)
+
+		exploded := gtidSet.Explode()
+		test.S(t).ExpectEquals(len(exploded), 3)
+		test.S(t).ExpectEquals(exploded[0].String(), "00020192-1111-1111-1111-111111111111:29")
+		test.S(t).ExpectEquals(exploded[1].String(), "00020192-1111-1111-1111-111111111111:30")
+		test.S(t).ExpectEquals(exploded[2].String(), "00020192-1111-1111-1111-111111111111:tag1:1")
+
+	}
+	{
+		// Multi valued tagged gtid with default interval
+		gtidSetVal := "00020192-1111-1111-1111-111111111111:29-30:tag1:1-4"
+		gtidSet, err := NewOracleGtidSet(gtidSetVal)
+		test.S(t).ExpectNil(err)
+
+		exploded := gtidSet.Explode()
+		test.S(t).ExpectEquals(len(exploded), 6)
+		test.S(t).ExpectEquals(exploded[0].String(), "00020192-1111-1111-1111-111111111111:29")
+		test.S(t).ExpectEquals(exploded[1].String(), "00020192-1111-1111-1111-111111111111:30")
+		test.S(t).ExpectEquals(exploded[2].String(), "00020192-1111-1111-1111-111111111111:tag1:1")
+		test.S(t).ExpectEquals(exploded[3].String(), "00020192-1111-1111-1111-111111111111:tag1:2")
+		test.S(t).ExpectEquals(exploded[4].String(), "00020192-1111-1111-1111-111111111111:tag1:3")
+		test.S(t).ExpectEquals(exploded[5].String(), "00020192-1111-1111-1111-111111111111:tag1:4")
+	}
+	{
+		// Gtid sets with multiple uuids
+		gtidSetVal :=
+			"00020192-1111-1111-1111-111111111111:29-30:tag1:123," +
+				"00020194-3333-3333-3333-333333333333:414-416:tag2:7-8," +
+				"00020199-2222-2222-2222-111111111111:tag3:1-2:5"
+		gtidSet, err := NewOracleGtidSet(gtidSetVal)
+		test.S(t).ExpectNil(err)
+
+		exploded := gtidSet.Explode()
+		test.S(t).ExpectEquals(len(exploded), 11)
+		test.S(t).ExpectEquals(exploded[0].String(), "00020192-1111-1111-1111-111111111111:29")
+		test.S(t).ExpectEquals(exploded[1].String(), "00020192-1111-1111-1111-111111111111:30")
+		test.S(t).ExpectEquals(exploded[2].String(), "00020192-1111-1111-1111-111111111111:tag1:123")
+		test.S(t).ExpectEquals(exploded[3].String(), "00020194-3333-3333-3333-333333333333:414")
+		test.S(t).ExpectEquals(exploded[4].String(), "00020194-3333-3333-3333-333333333333:415")
+		test.S(t).ExpectEquals(exploded[5].String(), "00020194-3333-3333-3333-333333333333:416")
+		test.S(t).ExpectEquals(exploded[6].String(), "00020194-3333-3333-3333-333333333333:tag2:7")
+		test.S(t).ExpectEquals(exploded[7].String(), "00020194-3333-3333-3333-333333333333:tag2:8")
+		test.S(t).ExpectEquals(exploded[8].String(), "00020199-2222-2222-2222-111111111111:tag3:1")
+		test.S(t).ExpectEquals(exploded[9].String(), "00020199-2222-2222-2222-111111111111:tag3:2")
+		test.S(t).ExpectEquals(exploded[10].String(), "00020199-2222-2222-2222-111111111111:tag3:5")
+	}
+
 }
 
 func TestNewOracleGtidSet(t *testing.T) {
+	{
+		gtidSetVal := "00020191-1111-1111-1111-111111111111:20-30," +
+			"00020192-3333-3333-3333-333333333333:7-8:tag1:1," +
+			"00020193-3333-3333-3333-333333333333:tag2:110-789:tag3:11447"
+		gtidSet, err := NewOracleGtidSet(gtidSetVal)
+		test.S(t).ExpectNil(err)
+
+		test.S(t).ExpectEquals(len(gtidSet.GtidEntries), 3)
+		test.S(t).ExpectEquals(gtidSet.GtidEntries[0].String(), "00020191-1111-1111-1111-111111111111:20-30")
+		test.S(t).ExpectEquals(gtidSet.GtidEntries[1].String(), "00020192-3333-3333-3333-333333333333:7-8:tag1:1")
+		test.S(t).ExpectEquals(gtidSet.GtidEntries[2].String(), "00020193-3333-3333-3333-333333333333:tag2:110-789:tag3:11447")
+	}
 	{
 		gtidSetVal := "00020192-1111-1111-1111-111111111111:20-30, 00020194-3333-3333-3333-333333333333:7-8"
 		gtidSet, err := NewOracleGtidSet(gtidSetVal)
@@ -107,6 +286,8 @@ func TestNewOracleGtidSet(t *testing.T) {
 
 func TestRemoveUUID(t *testing.T) {
 	gtidSetVal := "00020192-1111-1111-1111-111111111111:20-30, 00020194-3333-3333-3333-333333333333:7-8"
+	taggedGtidSetVal := "00020192-1111-1111-1111-111111111111:20-30:tag1:100-114:tag2:1-89," +
+		"00020194-3333-3333-3333-333333333333:7-8:tag1:51-200:tag2:44"
 	{
 		gtidSet, err := NewOracleGtidSet(gtidSetVal)
 		test.S(t).ExpectNil(err)
@@ -134,10 +315,27 @@ func TestRemoveUUID(t *testing.T) {
 		gtidSet.RemoveUUID("00020194-3333-3333-3333-333333333333")
 		test.S(t).ExpectTrue(gtidSet.IsEmpty())
 	}
+
+	// Test for tagged gtids
+	{
+		gtidSet, err := NewOracleGtidSet(taggedGtidSetVal)
+		test.S(t).ExpectNil(err)
+
+		test.S(t).ExpectEquals(len(gtidSet.GtidEntries), 2)
+
+		gtidSet.RemoveUUID("00020192-1111-1111-1111-111111111111")
+		test.S(t).ExpectEquals(len(gtidSet.GtidEntries), 1)
+		test.S(t).ExpectEquals(gtidSet.GtidEntries[0].String(), "00020194-3333-3333-3333-333333333333:7-8:tag1:51-200:tag2:44")
+
+		gtidSet.RemoveUUID("00020194-3333-3333-3333-333333333333")
+		test.S(t).ExpectTrue(gtidSet.IsEmpty())
+	}
 }
 
 func TestRetainUUID(t *testing.T) {
 	gtidSetVal := "00020192-1111-1111-1111-111111111111:20-30, 00020194-3333-3333-3333-333333333333:7-8"
+	taggedGtidSetVal := "00020192-1111-1111-1111-111111111111:20-30:tag1:100-114:tag2:1-89," +
+		"00020194-3333-3333-3333-333333333333:7-8:tag1:51-200:tag2:44"
 	{
 		gtidSet, err := NewOracleGtidSet(gtidSetVal)
 		test.S(t).ExpectNil(err)
@@ -157,10 +355,32 @@ func TestRetainUUID(t *testing.T) {
 		test.S(t).ExpectTrue(removed)
 		test.S(t).ExpectEquals(len(gtidSet.GtidEntries), 0)
 	}
+	{
+		gtidSet, err := NewOracleGtidSet(taggedGtidSetVal)
+		test.S(t).ExpectNil(err)
+
+		test.S(t).ExpectEquals(len(gtidSet.GtidEntries), 2)
+		removed := gtidSet.RetainUUID("00020194-3333-3333-3333-333333333333")
+		test.S(t).ExpectTrue(removed)
+		test.S(t).ExpectEquals(len(gtidSet.GtidEntries), 1)
+		test.S(t).ExpectEquals(gtidSet.GtidEntries[0].String(), "00020194-3333-3333-3333-333333333333:7-8:tag1:51-200:tag2:44")
+
+		removed = gtidSet.RetainUUID("00020194-3333-3333-3333-333333333333")
+		test.S(t).ExpectFalse(removed)
+		test.S(t).ExpectEquals(len(gtidSet.GtidEntries), 1)
+		test.S(t).ExpectEquals(gtidSet.GtidEntries[0].String(), "00020194-3333-3333-3333-333333333333:7-8:tag1:51-200:tag2:44")
+
+		removed = gtidSet.RetainUUID("230ea8ea-81e3-11e4-972a-e25ec4bd140a")
+		test.S(t).ExpectTrue(removed)
+		test.S(t).ExpectEquals(len(gtidSet.GtidEntries), 0)
+	}
 }
 
 func TestRetainUUIDs(t *testing.T) {
 	gtidSetVal := "00020192-1111-1111-1111-111111111111:20-30, 00020194-3333-3333-3333-333333333333:7-8"
+	taggedGtidSetVal := "00020192-1111-1111-1111-111111111111:20-30:tag1:100-114:tag2:1-89," +
+		"00020193-3333-3333-3333-333333333333:7-8:tag1:51-200:tag2:44," +
+		"00020194-3333-3333-3333-333333333333:7-8:tag4:151-209:tag2:44-47"
 	{
 		gtidSet, err := NewOracleGtidSet(gtidSetVal)
 		test.S(t).ExpectNil(err)
@@ -175,6 +395,26 @@ func TestRetainUUIDs(t *testing.T) {
 		test.S(t).ExpectFalse(removed)
 		test.S(t).ExpectEquals(len(gtidSet.GtidEntries), 1)
 		test.S(t).ExpectEquals(gtidSet.GtidEntries[0].String(), "00020194-3333-3333-3333-333333333333:7-8")
+
+		removed = gtidSet.RetainUUIDs([]string{"230ea8ea-81e3-11e4-972a-e25ec4bd140a"})
+		test.S(t).ExpectTrue(removed)
+		test.S(t).ExpectEquals(len(gtidSet.GtidEntries), 0)
+	}
+	{
+		gtidSet, err := NewOracleGtidSet(taggedGtidSetVal)
+		test.S(t).ExpectNil(err)
+
+		test.S(t).ExpectEquals(len(gtidSet.GtidEntries), 3)
+		removed := gtidSet.RetainUUIDs([]string{"00020192-1111-1111-1111-111111111111", "00020194-3333-3333-3333-333333333333"})
+		test.S(t).ExpectTrue(removed)
+		test.S(t).ExpectEquals(len(gtidSet.GtidEntries), 2)
+		test.S(t).ExpectEquals(gtidSet.GtidEntries[0].String(), "00020192-1111-1111-1111-111111111111:20-30:tag1:100-114:tag2:1-89")
+		test.S(t).ExpectEquals(gtidSet.GtidEntries[1].String(), "00020194-3333-3333-3333-333333333333:7-8:tag4:151-209:tag2:44-47")
+
+		removed = gtidSet.RetainUUIDs([]string{"00020194-3333-3333-3333-333333333333", "00020195-5555-5555-5555-333333333333"})
+		test.S(t).ExpectTrue(removed)
+		test.S(t).ExpectEquals(len(gtidSet.GtidEntries), 1)
+		test.S(t).ExpectEquals(gtidSet.GtidEntries[0].String(), "00020194-3333-3333-3333-333333333333:7-8:tag4:151-209:tag2:44-47")
 
 		removed = gtidSet.RetainUUIDs([]string{"230ea8ea-81e3-11e4-972a-e25ec4bd140a"})
 		test.S(t).ExpectTrue(removed)

--- a/go/inst/oracle_gtid_set_test.go
+++ b/go/inst/oracle_gtid_set_test.go
@@ -41,6 +41,12 @@ func TestNewOracleGtidSetEntry(t *testing.T) {
 		test.S(t).ExpectNotNil(err)
 	}
 	{
+		// Invalid tag name
+		uuidSet := "00020194-3333-3333-3333-333333333333:1-7:10-20:domain1.com:1"
+		_, err := NewOracleGtidSetEntry(uuidSet)
+		test.S(t).ExpectNotNil(err)
+	}
+	{
 		// Valid tag name but no interval after tag name
 		uuidSet := "00020194-3333-3333-3333-333333333333:1-7:10-20:tag1"
 		_, err := NewOracleGtidSetEntry(uuidSet)
@@ -96,7 +102,7 @@ func TestNewOracleGtidSetEntry(t *testing.T) {
 	}
 	{
 		// No default interval
-		uuidSet := "00020194-3333-3333-3333-333333333333:domain.com:1:51-56"
+		uuidSet := "00020194-3333-3333-3333-333333333333:domain:1:51-56"
 		entry, err := NewOracleGtidSetEntry(uuidSet)
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(entry.UUID, "00020194-3333-3333-3333-333333333333")
@@ -108,13 +114,13 @@ func TestNewOracleGtidSetEntry(t *testing.T) {
 		// There are two tagged interval ranges
 		test.S(t).ExpectEquals(len(entry.TaggedIv[0].Interval), 2)
 
-		test.S(t).ExpectEquals(entry.TaggedIv[0].Tag, "domain.com")
+		test.S(t).ExpectEquals(entry.TaggedIv[0].Tag, "domain")
 		test.S(t).ExpectEquals(entry.TaggedIv[0].Interval[0], "1")
 		test.S(t).ExpectEquals(entry.TaggedIv[0].Interval[1], "51-56")
 	}
 	{
 		// No default interval, multiple tagged intervals
-		uuidSet := "00020194-3333-3333-3333-333333333333:domain1.com:1:51-56:domain2.com:1-78:151-256:514"
+		uuidSet := "00020194-3333-3333-3333-333333333333:domain1:1:51-56:domain2:1-78:151-256:514"
 		entry, err := NewOracleGtidSetEntry(uuidSet)
 		test.S(t).ExpectNil(err)
 		test.S(t).ExpectEquals(entry.UUID, "00020194-3333-3333-3333-333333333333")
@@ -126,14 +132,14 @@ func TestNewOracleGtidSetEntry(t *testing.T) {
 		// tag 1 (domain1.com) has two interval ranges
 		test.S(t).ExpectEquals(len(entry.TaggedIv[0].Interval), 2)
 
-		test.S(t).ExpectEquals(entry.TaggedIv[0].Tag, "domain1.com")
+		test.S(t).ExpectEquals(entry.TaggedIv[0].Tag, "domain1")
 		test.S(t).ExpectEquals(entry.TaggedIv[0].Interval[0], "1")
 		test.S(t).ExpectEquals(entry.TaggedIv[0].Interval[1], "51-56")
 
 		// tag 2 (domain2.com) has three interval ranges
 		test.S(t).ExpectEquals(len(entry.TaggedIv[1].Interval), 3)
 
-		test.S(t).ExpectEquals(entry.TaggedIv[1].Tag, "domain2.com")
+		test.S(t).ExpectEquals(entry.TaggedIv[1].Tag, "domain2")
 		test.S(t).ExpectEquals(entry.TaggedIv[1].Interval[0], "1-78")
 		test.S(t).ExpectEquals(entry.TaggedIv[1].Interval[1], "151-256")
 		test.S(t).ExpectEquals(entry.TaggedIv[1].Interval[2], "514")

--- a/run/test-system.sh
+++ b/run/test-system.sh
@@ -11,8 +11,11 @@ export TARBALL_URL=https://dev.mysql.com/get/Downloads/MySQL-8.4/mysql-8.4.0-lin
 export RUN_TESTS=YES
 export ALLOW_TESTS_FAILURES=YES
 
+# Mount test/ directory on docker
+#export MOUNT_TEST_DIR=YES
+
 # It is also possible to specify custom ci-env
 #export CI_ENV_REPO=https://github.com/kamil-holubicki/orchestrator-ci-env.git
-#export CI_ENV_BRANCH=DISTMYSQL-140
+#export CI_ENV_BRANCH=DISTMYSQL-421
 
 script/dock system

--- a/run/test-system.sh
+++ b/run/test-system.sh
@@ -11,11 +11,11 @@ export TARBALL_URL=https://dev.mysql.com/get/Downloads/MySQL-8.4/mysql-8.4.0-lin
 export RUN_TESTS=YES
 export ALLOW_TESTS_FAILURES=YES
 
-# Mount test/ directory on docker
-#export MOUNT_TEST_DIR=YES
+# Mount tests/ directory on docker
+export MOUNT_TEST_DIR=YES
 
 # It is also possible to specify custom ci-env
-#export CI_ENV_REPO=https://github.com/kamil-holubicki/orchestrator-ci-env.git
-#export CI_ENV_BRANCH=DISTMYSQL-421
+#export CI_ENV_REPO=https://github.com/percona/orchestrator-ci-env.git
+#export CI_ENV_BRANCH=master
 
 script/dock system

--- a/script/dock
+++ b/script/dock
@@ -22,17 +22,22 @@ else
   CI_ENV_BRANCH_ENV=${CI_ENV_BRANCH}
 fi
 
+if [[ ${MOUNT_TEST_DIR} == "YES" ]] ; then
+  DOCKER_EXTRA_ARGS="-v $PWD/tests/:/orchestrator/tests/"
+else
+  DOCKER_EXTRA_ARGS=
+fi
 
 command="$1"
 
 case "$command" in
   "test")
     docker_target="orchestrator-test"
-    docker build . -f docker/Dockerfile.test -t "${docker_target}" && docker run --rm -it --env TARBALL_URL=${TARBALL_URL} --env RUN_TESTS=${RUN_TESTS} --env ALLOW_TESTS_FAILURES=${ALLOW_TESTS_FAILURES} "${docker_target}:latest"
+    docker build . -f docker/Dockerfile.test -t "${docker_target}" && docker run --rm -it --env TARBALL_URL=${TARBALL_URL} --env RUN_TESTS=${RUN_TESTS} --env ALLOW_TESTS_FAILURES=${ALLOW_TESTS_FAILURES} ${DOCKER_EXTRA_ARGS} "${docker_target}:latest"
     ;;
   "test-no-it")
     docker_target="orchestrator-test"
-    docker build . -f docker/Dockerfile.test -t "${docker_target}" && docker run --rm --env TARBALL_URL=${TARBALL_URL} --env RUN_TESTS=${RUN_TESTS} --env ALLOW_TESTS_FAILURES=${ALLOW_TESTS_FAILURES} "${docker_target}:latest"
+    docker build . -f docker/Dockerfile.test -t "${docker_target}" && docker run --rm --env TARBALL_URL=${TARBALL_URL} --env RUN_TESTS=${RUN_TESTS} --env ALLOW_TESTS_FAILURES=${ALLOW_TESTS_FAILURES} ${DOCKER_EXTRA_ARGS} "${docker_target}:latest"
     ;;
   "alpine")
     docker_target="orchestrator-alpine"
@@ -61,11 +66,11 @@ case "$command" in
     ;;
   "system")
     docker_target="orchestrator-system"
-    docker build . -f docker/Dockerfile.system -t "${docker_target}" --build-arg ci_env_repo=${CI_ENV_REPO_ENV} --build-arg ci_env_branch=${CI_ENV_BRANCH_ENV} && docker run --rm -it -p 3000:3000 --env TARBALL_URL=${TARBALL_URL} --env RUN_TESTS=${RUN_TESTS} --env ALLOW_TESTS_FAILURES=${ALLOW_TESTS_FAILURES} "${docker_target}:latest"
+    docker build . -f docker/Dockerfile.system -t "${docker_target}" --build-arg ci_env_repo=${CI_ENV_REPO_ENV} --build-arg ci_env_branch=${CI_ENV_BRANCH_ENV} && docker run --rm -it -p 3000:3000 --env TARBALL_URL=${TARBALL_URL} --env RUN_TESTS=${RUN_TESTS} --env ALLOW_TESTS_FAILURES=${ALLOW_TESTS_FAILURES} ${DOCKER_EXTRA_ARGS} "${docker_target}:latest"
     ;;
   "system-no-it")
     docker_target="orchestrator-system"
-    docker build . -f docker/Dockerfile.system -t "${docker_target}" --build-arg ci_env_repo=${CI_ENV_REPO_ENV} --build-arg ci_env_branch=${CI_ENV_BRANCH_ENV} && docker run --rm --env TARBALL_URL=${TARBALL_URL} --env RUN_TESTS=${RUN_TESTS} --env ALLOW_TESTS_FAILURES=${ALLOW_TESTS_FAILURES} "${docker_target}:latest"
+    docker build . -f docker/Dockerfile.system -t "${docker_target}" --build-arg ci_env_repo=${CI_ENV_REPO_ENV} --build-arg ci_env_branch=${CI_ENV_BRANCH_ENV} && docker run --rm --env TARBALL_URL=${TARBALL_URL} --env RUN_TESTS=${RUN_TESTS} --env ALLOW_TESTS_FAILURES=${ALLOW_TESTS_FAILURES} ${DOCKER_EXTRA_ARGS} "${docker_target}:latest"
     ;;
   "raft")
     docker_target="orchestrator-raft"

--- a/script/dock
+++ b/script/dock
@@ -23,7 +23,7 @@ else
 fi
 
 if [[ ${MOUNT_TEST_DIR} == "YES" ]] ; then
-  DOCKER_EXTRA_ARGS="-v $PWD/tests/:/orchestrator/tests/"
+  DOCKER_EXTRA_ARGS="--mount type=bind,source=$PWD/tests/,destination=/orchestrator/tests/"
 else
   DOCKER_EXTRA_ARGS=
 fi

--- a/tests/system/gtid-errant/09-inject-errant-tagged-gtid/expect_output
+++ b/tests/system/gtid-errant/09-inject-errant-tagged-gtid/expect_output
@@ -1,0 +1,25 @@
+======== BEGIN =======
+Topology:
+127.0.0.1:10111    |0s|ok|8.4.0|rw|ROW|>>,GTID       
++ 127.0.0.1:10112  |0s|ok|8.4.0|ro|ROW|>>,GTID       
++ 127.0.0.1:10113  |0s|ok|8.4.0|ro|ROW|>>,GTID:errant
+  + 127.0.0.1:10114|0s|ok|8.4.0|ro|ROW|>>,GTID       
+
+Errant GTID on all nodes:
+
+00010113-3333-3333-3333-333333333333:tag1:1-2:4-5:7:tag2:100-101:tag3:4-5
+
+
+
+Errant GTID on 127.0.0.1:10113:
+00010113-3333-3333-3333-333333333333:tag1:1-2:4-5:7:tag2:100-101:tag3:4-5
+
+Injecting empty gtids in place of errant gtids
+127.0.0.1:10113
+
+Errant GTIDs on all nodes (should be empty):
+
+
+
+
+======== END =======

--- a/tests/system/gtid-errant/09-inject-errant-tagged-gtid/run
+++ b/tests/system/gtid-errant/09-inject-errant-tagged-gtid/run
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+echo "======== BEGIN ======="
+echo "Topology:"
+orchestrator-client -c topology-tabulated -alias ci
+
+echo
+echo "Errant GTID on all nodes:"
+orchestrator-client -c api -path all-instances | jq -r '.[].GtidErrant'
+
+echo
+echo "Errant GTID on 127.0.0.1:10113:"
+orchestrator-client -c which-gtid-errant -i 127.0.0.1:10113
+
+echo
+echo "Injecting empty gtids in place of errant gtids"
+orchestrator-client -c gtid-errant-inject-empty -i127.0.0.1:10113
+
+# Sleep for some time for it to inject empty gtids
+sleep 5
+
+echo
+echo "Errant GTIDs on all nodes (should be empty):"
+orchestrator-client -c api -path all-instances | jq -r '.[].GtidErrant'
+echo "======== END ======="

--- a/tests/system/gtid-errant/09-inject-errant-tagged-gtid/setup
+++ b/tests/system/gtid-errant/09-inject-errant-tagged-gtid/setup
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -e
+
+orchestrator-client -c topology-tabulated -alias ci
+orchestrator-client -c relocate -i 127.0.0.1:10114 -d 127.0.0.1:10113
+sleep 3
+
+uuid=$(mysql -BN -uci -pci -h 127.0.0.1 --port=10113 -e "select @@server_uuid;")
+
+cat > /tmp/gtid-errant.sql <<EOF
+set gtid_next="$uuid:tag1:1";
+begin;
+update test.heartbeat set hint="gtid-errant";
+commit;
+
+set gtid_next="$uuid:tag1:2";
+begin;
+update test.heartbeat set hint="gtid-errant";
+commit;
+
+set gtid_next="$uuid:tag1:4";
+begin;
+update test.heartbeat set hint="gtid-errant";
+commit;
+
+set gtid_next="$uuid:tag1:5";
+begin;
+update test.heartbeat set hint="gtid-errant";
+commit;
+
+set gtid_next="$uuid:tag1:7";
+begin;
+update test.heartbeat set hint="gtid-errant";
+commit;
+
+set gtid_next="$uuid:tag2:100";
+begin;
+update test.heartbeat set hint="gtid-errant";
+commit;
+
+set gtid_next="$uuid:tag2:101";
+begin;
+update test.heartbeat set hint="gtid-errant";
+commit;
+
+set gtid_next="$uuid:tag3:4";
+begin;
+update test.heartbeat set hint="gtid-errant";
+commit;
+
+set gtid_next="$uuid:tag3:5";
+begin;
+update test.heartbeat set hint="gtid-errant";
+commit;
+
+EOF
+
+mysql -uci -pci -h 127.0.0.1 --port=10113 < /tmp/gtid-errant.sql
+sleep 3
+rm /tmp/gtid-errant.sql

--- a/tests/system/gtid-errant/teardown
+++ b/tests/system/gtid-errant/teardown
@@ -1,0 +1,1 @@
+orchestrator-client -c relocate -i 127.0.0.1:10114 -d 127.0.0.1:10111


### PR DESCRIPTION
    DISTMYSQL-412: Orchestrator should handle tagged GTIDs
    
    https://perconadev.atlassian.net/browse/DISTMYSQL-412
    
    Added support for the tagged GTIDs in Orchestrator.
    
    Added necessary unit tests and system tests.
    
    Added the option DOCKER_EXTRA_ARGS in the script/dock file to
    automatically mount `tests` directory during docker runs for
    convenient testing of system and integration tests