### PR TITLE
distinguish v6 IP addresses in RaftAdvertise host

### DIFF
--- a/go/raft/raft.go
+++ b/go/raft/raft.go
@@ -188,7 +188,12 @@ func normalizeRaftHostnameIP(host string) (string, error) {
 	}
 	// resolve success!
 	for _, ip := range ips {
-		return ip.String(), nil
+		addr := net.ParseIP(ip.String())
+		if addr != nil && addr.To4() == nil {
+			return fmt.Sprintf("[%s]", ip.String()), nil
+		} else {
+			return ip.String(), nil
+		}
 	}
 	return host, fmt.Errorf("%+v resolved but no IP found", host)
 }


### PR DESCRIPTION
Avoid error when RaftAdvertise is IPv6 address:
ERROR failed to open raft store: address fcff:0:675:2::bf87:10008: too many colons in address

### Description
I try run ps-operator in k8s with IPv6 addresses and see error in orchestrator:

```
+ NAMESPACE=racktables-prestable
+ jq -M '. + {
        HTTPAdvertise:"http://rt-prestable-orc-0.rt-prestable:3000",
        RaftAdvertise:"rt-prestable-orc-0.rt-prestable",
        RaftBind:"rt-prestable-orc-0.rt-prestable-orc.rt-prestable",
        RaftEnabled: true,
        MySQLTopologyUseMutualTLS: true,
        MySQLTopologySSLSkipVerify: true,
        MySQLTopologySSLPrivateKeyFile:"/etc/orchestrator/ssl/tls.key",
        MySQLTopologySSLCertFile:"/etc/orchestrator/ssl/tls.crt",
        MySQLTopologySSLCAFile:"/etc/orchestrator/ssl/ca.crt",
        RaftNodes:[]
    }' /etc/orchestrator/orchestrator.conf.json
+ '[' -f /etc/orchestrator/config/orchestrator.conf.json ']'
+ jq -M -s '.[0] * .[1]' /etc/orchestrator/orchestrator.conf.json /etc/orchestrator/config/orchestrator.conf.json
+ exec /usr/local/orchestrator/orchestrator -config /etc/orchestrator/orchestrator.conf.json http
2024-08-20 15:31:29 DEBUG Connected to orchestrator backend: sqlite on /var/lib/orchestrator/orc.db
...
2024-08-20 15:31:29 DEBUG Setting up raft
2024-08-20 15:31:29 DEBUG Queue.startMonitoring(DEFAULT)
2024-08-20 15:31:29 INFO Starting HTTP listener on :3000
2024-08-20 15:31:29 ERROR failed to open raft store: address fcff:0:675:2::bf87:10008: too many colons in address
2024-08-20 15:31:29 FATAL 2024-08-20 15:31:29 ERROR failed to open raft store: address fcff:0:675:2::bf87:10008: too many colons in address
```


