### PR TITLE
DISTMYSQL-466: RestartReplicationQuick called even from Orchestrator cluster where recovery has been globally disabled

### DIFF
--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -1373,6 +1373,8 @@ func readInstanceRow(m sqlutils.RowMap) *Instance {
 		instance.Problems = append(instance.Problems, "group_replication_member_not_online")
 	}
 
+	instance.QSP = GetQueryStringProvider(instance.Version)
+
 	return instance
 }
 

--- a/script/build
+++ b/script/build
@@ -29,4 +29,6 @@ cd .gopath/src/github.com/openark/orchestrator
 # We put the binaries directly into the bindir, because we have no need for shim wrappers
 go build -o "$bindir/orchestrator" -ldflags "-X main.AppVersion=${version} -X main.BuildDescribe=${describe}" ./go/cmd/orchestrator/main.go
 
+chmod -R +w "${GOPATH}"
+
 rsync -qa ./resources $bindir/


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/DISTMYSQL-466

Problem:
When recovery is disabled globally, UnreachableMasterWithLaggingReplicas and UnreachableIntermediateMasterWithLaggingReplicas cases cause replica io thread to be restarted.

Cause:
Commit 98bd7f0f added the feature allowing global recovery disable

Commit fc33f3ee moved the implementation to
executeCheckAndRecoverFunction

Commit b761fa3d introduced runEmergencyOperations() function. Its purpose was to read topology instance to speed up recovery. The instance was read, then recovery was skipped if disabled globally.

Commit 464a3c1d and 684d6e24 caused the regression. They introduced the call to emergentlyRestartReplicationOnTopologyInstance() from runEmergencyOperations().
https://github.com/openark/orchestrator/pull/572 and https://github.com/openark/orchestrator/pull/1005 provide the detailed explanation, why it was done.

Solution:
If recovery was disabled globally, and this is not forced discovery, skip restart of replicas.

Additionally fixed Instance object read from Orchestrator's backend DB. Such and object was missing QSP member (Query String Provider). As the consequence any query related to master/slave <-> source/replica could not be resolved and failed (because nil string query was executed)

<!--
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR
-->

Related issue: https://github.com/openark/orchestrator/issues/0123456789


### Description

This PR [briefly explain what is does]

<!--
Please make sure that:

- [ ] contributed code is using same conventions as original code

Please make sure the PR passes CI tests. For your information, CI tests the following:

- code is formatted via `gofmt` (please avoid `goimports`)
- code passes compilation
- code passes unit tests
- code passes integration tests with MySQL backend
- code passes integration tests with SQLite backend
- There are no orphaned docs/ pages (there's some link in the docs to point to any page)
- upgrade from previous version (`master` branch) is successful
 -->
