### PR TITLE
DISTMYSQL-432: inject-errant-tagged-gtid test fails with 8.4.2 server

### DIFF
--- a/tests/system/gtid-errant/09-inject-errant-tagged-gtid/expect_output
+++ b/tests/system/gtid-errant/09-inject-errant-tagged-gtid/expect_output
@@ -1,9 +1,9 @@
 ======== BEGIN =======
 Topology:
-127.0.0.1:10111    |0s|ok|8.4.0|rw|ROW|>>,GTID       
-+ 127.0.0.1:10112  |0s|ok|8.4.0|ro|ROW|>>,GTID       
-+ 127.0.0.1:10113  |0s|ok|8.4.0|ro|ROW|>>,GTID:errant
-  + 127.0.0.1:10114|0s|ok|8.4.0|ro|ROW|>>,GTID       
+127.0.0.1:10111    |0s|ok|rw|ROW|>>,GTID
++ 127.0.0.1:10112  |0s|ok|ro|ROW|>>,GTID
++ 127.0.0.1:10113  |0s|ok|ro|ROW|>>,GTID:errant
+  + 127.0.0.1:10114|0s|ok|ro|ROW|>>,GTID
 
 Errant GTID on all nodes:
 

--- a/tests/system/gtid-errant/09-inject-errant-tagged-gtid/run
+++ b/tests/system/gtid-errant/09-inject-errant-tagged-gtid/run
@@ -2,7 +2,7 @@
 
 echo "======== BEGIN ======="
 echo "Topology:"
-orchestrator-client -c topology-tabulated -alias ci
+orchestrator-client -c topology-tabulated -alias ci | cut -d '|' -f 1,2,3,5,6,7
 
 echo
 echo "Errant GTID on all nodes:"


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/DISTMYSQL-432

***
Removed the hardcoded version number from the expect_output file

***
Testing Done:
---

PS-8.4.2-2
---
Jenkins (PS-8.4.2-2): https://ps80.cd.percona.com/job/mysql-orchestrator-pipeline/55/

Result:
![image](https://github.com/user-attachments/assets/fb5c27f7-5871-47c7-bb07-58d5465b3f74)


MySQL-8.4.0
---
Jenkins (MySQL-8.4): https://ps80.cd.percona.com/job/mysql-orchestrator-pipeline/56/
Result:
![image](https://github.com/user-attachments/assets/0608dd85-1c14-41be-9f72-7f22549de45c)
