### PR TITLE
DISTMYSQL-440: Orchestrator should use the new source-replica terminology for any higher version than 8.3

### DIFF
--- a/go/inst/instance_topology.go
+++ b/go/inst/instance_topology.go
@@ -1037,6 +1037,11 @@ func MakeCoMaster(instanceKey *InstanceKey) (*Instance, error) {
 		if err != nil {
 			goto Cleanup
 		}
+	} else {
+		_, err = EnableMasterGetSourcePublicKey(&master.Key)
+		if err != nil {
+			goto Cleanup
+		}
 	}
 
 	if instance.UsingOracleGTID {

--- a/go/inst/query_string_provider.go
+++ b/go/inst/query_string_provider.go
@@ -1,7 +1,5 @@
 package inst
 
-import "strings"
-
 type QueryStringKey int
 
 type QueryStringProvider struct {
@@ -344,7 +342,7 @@ var queryStringProvider84 = QueryStringProvider{
 }
 
 func GetQueryStringProvider(version string) QueryStringProvider {
-	if strings.HasPrefix(version, "8.4") {
+	if version >= "8.4" {
 		return queryStringProvider84
 	}
 	return queryStringProvider80

--- a/go/inst/query_string_provider.go
+++ b/go/inst/query_string_provider.go
@@ -53,6 +53,7 @@ const (
 	change_master_to_with_params
 	change_master_to_master_delay
 	set_sql_slave_skip_counter
+	change_master_to_get_source_public_key
 )
 
 func (qps *QueryStringProvider) log_slave_updates() string {
@@ -235,6 +236,10 @@ func (qps *QueryStringProvider) set_sql_slave_skip_counter() string {
 	return qps.queries[set_sql_slave_skip_counter]
 }
 
+func (qps *QueryStringProvider) change_master_to_get_source_public_key() string {
+	return qps.queries[change_master_to_get_source_public_key]
+}
+
 var queryStrings80 = map[QueryStringKey]string{
 	log_slave_updates:         "log_slave_updates",
 	start_slave:               "start slave",
@@ -282,6 +287,7 @@ var queryStrings80 = map[QueryStringKey]string{
 	change_master_to_with_params:                          "change master to %s",
 	change_master_to_master_delay:                         "change master to master_delay=%d",
 	set_sql_slave_skip_counter:                            "set global sql_slave_skip_counter := 1",
+	change_master_to_get_source_public_key:                "select 1",
 }
 
 var queryStrings84 = map[QueryStringKey]string{
@@ -331,6 +337,7 @@ var queryStrings84 = map[QueryStringKey]string{
 	change_master_to_with_params:                          "change replication source to %s",
 	change_master_to_master_delay:                         "change replication source to source_delay=%d",
 	set_sql_slave_skip_counter:                            "set global sql_replica_skip_counter := 1",
+	change_master_to_get_source_public_key:                "change replication source to get_source_public_key=1",
 }
 
 var queryStringProvider80 = QueryStringProvider{

--- a/go/logic/topology_recovery.go
+++ b/go/logic/topology_recovery.go
@@ -2218,6 +2218,11 @@ func GracefulMasterTakeover(clusterName string, designatedKey *inst.InstanceKey,
 		if err == nil {
 			err = enableSSLErr
 		}
+	} else {
+		_, enableSSLErr := inst.EnableMasterGetSourcePublicKey(&clusterMaster.Key)
+		if err == nil {
+			err = enableSSLErr
+		}
 	}
 	if auto {
 		_, startReplicationErr := inst.StartReplication(&clusterMaster.Key)

--- a/tests/system/test-retry
+++ b/tests/system/test-retry
@@ -4,5 +4,6 @@ for i in $(seq 1 10) ; do
   if "$@" ; then
     exit 0
   fi
+  sleep 1
 done
 exit 1


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/DISTMYSQL-440

Problem 1:
Orchestrator uses source-replica queries only for 8.4.x versions.
For versions like 9.x it uses old master-slave queries.

Reason:
Query String Provider detects only 8.4.x versions as "new ones".

Solution:
Change "new version" detection method.

Problem 2:
MySQL 9.x removed native authentication plugin.
Now caching_sha2_password is used, and requres either secure SSL
connection or at least RSA-based password exchange during the client
authentication. If replication uses SSL channels, and we move the source
to be replica, we need to enable SSL on it. We do it by executing
'change replication source to source_ssl=1' if the new source has SSL
enabled.
However, if replication does not use SSL it means we used RSA, so after
making the source to be replica, we need to enable RSA-based login on it
by executing 'change replication source to get_source_public_key=1'.

Additionally, updated dbdeployer to be compatible with 9.0 (replication
user does not use native authentication)