### PR TITLE
DISTMYSQL-418: Introduce separate discovery queue for unhealthy instances

### DIFF
--- a/docs/configuration-discovery-advanced.md
+++ b/docs/configuration-discovery-advanced.md
@@ -1,0 +1,79 @@
+# Configuration: advanced discovery
+
+The Orchestrator uses an internal queue to manage instances for discovery. When an instance is ready for discovery, it gets added to the queue. Discovery workers process the queue. The `DiscoveryMaxConcurrency` setting in a configuration file controls the number of workers. This setting determines how many discoveries can happen in parallel.
+
+The Orchestrator uses this mechanism to periodically monitor all instances. `InstancePollSeconds` configuration parameter says how often the Orchestrator should refresh the information.
+
+When there is a lot of inaccessible or unhealthy instances, the Orchestrator may lose the proper view of the cluster and be late with needed recovery actions. This is because discoveries of such instances may take a long time and finish with failure anyway, at the same time consuming workers from the discovery workers pool. Healthy instances wait in the queue and they are not checked in a timely manner.
+
+To avoid this, Orchestrator can be configured to maintain a separate discovery queue for unhealthy instances. This queue is processed by a separate pool of workers. Additionally, an exponential time backoff mechanism can be applied for rechecking such instances.
+
+Configuration example:
+```json
+{
+  "DeadInstanceDiscoveryMaxConcurrency": 100,
+  "DeadInstancePollSecondsMultiplyFactor": 1.5,
+  "DeadInstancePollSecondsMax": 60,
+  "DeadInstanceDiscoveryLogsEnabled": true
+}
+```
+
+`DeadInstanceDiscoveryMaxConcurrency` (default: 0) - Determines the number of discovery workers dedicated to dead instances. If this pool size is grater than 0, the Orchestrator maintains a separate queue for dead instances.
+
+`DeadInstancePollSecondsMultiplyFactor` (default: 1) - Floating point number, allowed values are >= 1. Determines how aggressive the backoff mechanism is. By default, when `DeadInstancePollSecondsMultiplyFactor = 1`, the instance is checked every `InstancePollSeconds` seconds. If the parameter value is greater than 1, every consecutive try `n` is done after the period calculated according to the formula:
+
+dT(n) = InstancePollSeconds * DeadInstancePollSecondsMultiplyFactor ^ (n-1)
+
+Example:
+
+Let's use `D` as `DeadInstancePollSecondsMultiplyFactor`
+
+f(1) = 1\
+f(2) = f(1) * D\
+f(3) = f(2) * D\
+f(4) = f(3) * D
+
+That means:
+
+f(4) = 1 * D * D * D = D^3
+
+or in other words
+
+f(n) = DeadInstancePollSecondsMultiplyFactor ^ (n-1)
+
+so:
+
+dT(n) = InstancePollSeconds * f(n)\
+dT(n) = InstancePollSeconds * DeadInstancePollSecondsMultiplyFactor ^ (n-1)
+
+Note that `DeadInstanceDiscoveryMaxConcurrency` controls if the separate pool of discovery workers is created but has no impact on the backoff mechanism controlled by `DeadInstancePollSecondsMultiplyFactor`. It has the following implications:
+
+1. `DeadInstanceDiscoveryMaxConcurrency > 0` and `DeadInstancePollSecondsMultiplyFactor > 1`:\
+The separate discovery queue for dead instances is created, and dead instances are checked by a dedicated pool of go workers, and the instance is checked with exponential backoff mechanism time
+2. `DeadInstanceDiscoveryMaxConcurrency = 0` and `DeadInstancePollSecondsMultiplyFactor > 1`:\
+No separate discovery queue for dead instances is created, and dead instances are checked by the same pool of go workers as healthy instances however, an exponential backoff mechanism is applied for dead instances
+3. `DeadInstanceDiscoveryMaxConcurrency > 0` and `DeadInstancePollSecondsMultiplyFactor = 1`:\
+A separate discovery queue for dead instances is created, and dead instances are checked by a dedicated pool of go workers. No exponential backoff mechanism is applied for dead instances
+4. `DeadInstanceDiscoveryMaxConcurrency = 0` and `DeadInstancePollSecondsMultiplyFactor = 1`:\
+There is no separate discovery queue for dead instances, no dedicated go workers, no backoff mechanism. This is the default working mode.
+
+`DeadInstancePollSecondsMax` (default: 300) - Controls the maximum time for backoff mechanism. If the backoff calculation goes beyond this value, it is considered as saturated and stays at `DeadInstancePollSecondsMax`
+
+## Diagnostics
+Orchestrator provides `debug/metrics` web endpoint for diagnostics.
+
+`discoveries.dead_instances` - provides the number of instances currently registered as dead.\
+`discoveries.dead_instances_queue_length` - provides the current length of the queue dedicate for dead instances. Note this is valid only when `DeadInstanceDiscoveryMaxConcurrency > 0`, so when a separate queue is used. In other cases it is always zero.
+
+Other diagnostics endpoints:
+
+`api/discovery-queue-metrics-raw/:seconds` - provides the raw metrics for a given time for the `DEFAULT` discovery queue.\
+`api/discovery-queue-metrics-raw/:queue/:seconds` - provides the raw metrics for a given time for the supplied (`DEFAULT` or `DEADINSTANCES`) discovery queue.\
+`discovery-queue-metrics-aggregated/:seconds` - provides aggregated metrics for a given time for the `DEFAULT` discovery queue.\
+`discovery-queue-metrics-aggregated/:queue/:seconds` - provides aggregated metrics for a given time for the supplied (`DEFAULT` or `DEADINSTANCES`) discovery queue.
+
+
+Note that `DEADINSTANCES` queue is available only if `DeadInstanceDiscoveryMaxConcurrency > 0`
+
+## Logging
+Logging of dead instances discovery process is controlled vial `DeadInstanceDiscoveryLogsEnabled` bool parameter. It is disabled by default.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,6 +10,7 @@ Use the following small steps to configure `orchestrator`:
 
 - [Backend](configuration-backend.md)
 - [Discovery: basic](configuration-discovery-basic.md)
+- [Discovery: advanced](configuration-discovery-advanced.md)
 - [Discovery: resolving names](configuration-discovery-resolve.md)
 - [Discovery: classifying servers](configuration-discovery-classifying.md)
 - [Discovery: Pseudo-GTID](configuration-discovery-pseudo-gtid.md)

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -142,6 +142,10 @@ type Configuration struct {
 	DiscoverByShowSlaveHosts                   bool     // Attempt SHOW SLAVE HOSTS before PROCESSLIST
 	UseSuperReadOnly                           bool     // Should orchestrator super_read_only any time it sets read_only
 	InstancePollSeconds                        uint     // Number of seconds between instance reads
+	DeadInstancePollSecondsMultiplyFactor      float32  // InstancePoolSeconds increase factor for dead instances read time calculation
+	DeadInstancePollSecondsMax                 uint     // Maximum delay between dead instance read attempts
+	DeadInstanceDiscoveryMaxConcurrency        uint     // Number of goroutines doing dead hosts discovery
+	DeadInstanceDiscoveryLogsEnabled           bool     // Enable logs related to dead instances discoveries
 	ReasonableInstanceCheckSeconds             uint     // Number of seconds an instance read is allowed to take before it is considered invalid, i.e. before LastCheckValid will be false
 	InstanceWriteBufferSize                    int      // Instance write buffer size (max number of instances to flush in one INSERT ODKU)
 	BufferInstanceWrites                       bool     // Set to 'true' for write-optimization on backend table (compromise: writes can be stale and overwrite non stale data)
@@ -330,6 +334,10 @@ func newConfiguration() *Configuration {
 		DefaultInstancePort:                        3306,
 		TLSCacheTTLFactor:                          100,
 		InstancePollSeconds:                        5,
+		DeadInstancePollSecondsMultiplyFactor:      1,
+		DeadInstancePollSecondsMax:                 5 * 60,
+		DeadInstanceDiscoveryMaxConcurrency:        0,
+		DeadInstanceDiscoveryLogsEnabled:           false,
 		ReasonableInstanceCheckSeconds:             1,
 		InstanceWriteBufferSize:                    100,
 		BufferInstanceWrites:                       false,
@@ -626,6 +634,13 @@ func (this *Configuration) postReadAdjustments() error {
 		this.ReasonableLockedSemiSyncMasterSeconds = uint(this.ReasonableReplicationLagSeconds)
 	}
 
+	if this.DeadInstancePollSecondsMultiplyFactor < 1 {
+		return fmt.Errorf("DeadInstancePollSecondsMultiplyFactor can not be smaller than 1")
+	}
+
+	if this.DeadInstancePollSecondsMax < this.InstancePollSeconds {
+		return fmt.Errorf(("DeadInstancePollSecondsMax can not be smaller than InstancePollSeconds"))
+	}
 	return nil
 }
 

--- a/go/discovery/queue.go
+++ b/go/discovery/queue.go
@@ -69,6 +69,15 @@ func StopMonitoring() {
 	}
 }
 
+func ReturnQueue(name string) *Queue {
+	dcLock.Lock()
+	defer dcLock.Unlock()
+	if q, found := discoveryQueue[name]; found {
+		return q
+	}
+	return nil
+}
+
 // CreateOrReturnQueue allows for creation of a new discovery queue or
 // returning a pointer to an existing one given the name.
 func CreateOrReturnQueue(name string) *Queue {

--- a/go/inst/dead_instance_filter.go
+++ b/go/inst/dead_instance_filter.go
@@ -1,0 +1,141 @@
+package inst
+
+import (
+	"sync"
+	"time"
+
+	"github.com/openark/golib/log"
+	"github.com/openark/orchestrator/go/config"
+	"github.com/rcrowley/go-metrics"
+)
+
+// The behavior depends on settings:
+// 1. DeadInstanceDiscoveryMaxConcurrency > 0 and DeadInstancePollSecondsMultiplyFactor > 1:
+//    The separate discovery queue for dead instances is created and dead instances
+// 	  are checked by dedicated pool of go workers
+//    and the instance is checked with exponential backoff mechanism time
+// 2. DeadInstanceDiscoveryMaxConcurrency = 0 and DeadInstancePollSecondsMultiplyFactor > 1:
+//    No separate discovery queue for dead instances is created and dead instances
+//    are checked by the same pool of go workers as healthy instances, however
+//    an exponential backoff mechanism is applied for dead instances
+// 3. DeadInstanceDiscoveryMaxConcurrency > 0 and DeadInstancePollSecondsMultiplyFactor = 1:
+//    The separate discovery queue for dead instances is created and dead instances
+//    are checked by dedicated pool of go workers. No exponential backoff mechanism
+//    is applied for dead instances
+// 4. DeadInstanceDiscoveryMaxConcurrency = 0 and DeadInstancePollSecondsMultiplyFactor = 1:
+//    No separate discovery queue for dead instances, no dedicated go workers,
+//    no backoff mechanism. This is the default working mode.
+//
+// We register a dead instance always. It shouldn't be a big overhead,
+// and we will get the info about the dead instances count.
+
+type deadInstance struct {
+	DelayFactor   float32
+	NextCheckTime time.Time
+	TryCnt        int
+}
+
+type deadInstancesFilter struct {
+	deadInstances      map[InstanceKey]deadInstance
+	deadInstancesMutex sync.RWMutex
+}
+
+var DeadInstancesFilter deadInstancesFilter
+
+var deadInstancesCounter = metrics.NewCounter()
+
+func init() {
+	metrics.Register("discoveries.dead_instances", deadInstancesCounter)
+	DeadInstancesFilter.deadInstances = make(map[InstanceKey]deadInstance)
+	DeadInstancesFilter.deadInstancesMutex = sync.RWMutex{}
+}
+
+// RegisterInstance registers a given instance in a dead instances cache.
+// Once the instance is registered its discovery can be delayed with exponential
+// backoff mechanism according to DeadInstancePollSecondsMultiplyFactor value.
+// During the registration, next desired check time is calculated basing on
+// the current delay factor, DeadInstancePollSecondsMultiplyFactor and
+// DeadInstancePollSecondsMax parameters.
+func (f *deadInstancesFilter) RegisterInstance(instanceKey *InstanceKey) {
+	delayFactor := float32(1)
+	previousTry := 0
+
+	f.deadInstancesMutex.Lock()
+	defer f.deadInstancesMutex.Unlock()
+
+	instance, exists := f.deadInstances[*instanceKey]
+	if exists {
+		delayFactor = config.Config.DeadInstancePollSecondsMultiplyFactor * instance.DelayFactor
+		previousTry = instance.TryCnt
+	} else {
+		deadInstancesCounter.Inc(1)
+	}
+
+	maxDelay := time.Duration(config.Config.DeadInstancePollSecondsMax) * time.Second
+	currentDelay := time.Duration(delayFactor*float32(config.Config.InstancePollSeconds)) * time.Second
+
+	// needed only for the debug log below
+	delayFactorTmp := delayFactor
+
+	if currentDelay > maxDelay {
+		// saturation
+		currentDelay = maxDelay
+		delayFactor = instance.DelayFactor // back to previous one
+	}
+	nextCheck := time.Now().Add(currentDelay)
+
+	instance = deadInstance{
+		DelayFactor:   delayFactor,
+		NextCheckTime: nextCheck,
+		TryCnt:        previousTry + 1,
+	}
+	f.deadInstances[*instanceKey] = instance
+
+	if config.Config.DeadInstanceDiscoveryLogsEnabled {
+		log.Debugf("Dead instance registered %v:%v. Iteration: %v. Current delay factor: %v (next check in %v (on %v))",
+			instanceKey.Hostname, instanceKey.Port, instance.TryCnt, delayFactorTmp, currentDelay, instance.NextCheckTime)
+	}
+}
+
+// UnregisterInstace removes the given instance from dead instances cache.
+func (f *deadInstancesFilter) UnregisterInstance(instanceKey *InstanceKey) {
+	f.deadInstancesMutex.Lock()
+	defer f.deadInstancesMutex.Unlock()
+
+	instance, exists := f.deadInstances[*instanceKey]
+	if exists {
+		if config.Config.DeadInstanceDiscoveryLogsEnabled {
+			log.Debugf("Dead instance unregistered: %v:%v after iteration: %v",
+				instanceKey.Hostname, instanceKey.Port, instance.TryCnt)
+		}
+		deadInstancesCounter.Dec(1)
+		delete(f.deadInstances, *instanceKey)
+	}
+}
+
+// InstanceRecheckNeeded checks if a given instance is registered in a dead instances
+// cache and if it is, is it time to rediscover it.
+// It returns two boolean values:
+// - The first boolean indicates if the instance is registered.
+// - The second boolean, indicates if it is time to rediscover the node.
+func (f *deadInstancesFilter) InstanceRecheckNeeded(instanceKey *InstanceKey) (bool, bool) {
+	f.deadInstancesMutex.RLock()
+	defer f.deadInstancesMutex.RUnlock()
+
+	instance, exists := f.deadInstances[*instanceKey]
+
+	if !exists {
+		return exists, false
+	}
+
+	if instance.NextCheckTime.After(time.Now()) {
+		// recheck time still in the future
+		return exists, false
+	}
+
+	if config.Config.DeadInstanceDiscoveryLogsEnabled {
+		log.Debugf("Dead instance recheck: %v:%v. Iteration: %v",
+			instanceKey.Hostname, instanceKey.Port, instance.TryCnt)
+	}
+	return exists, true
+}

--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -382,6 +382,7 @@ func ReadTopologyInstanceBufferable(instanceKey *InstanceKey, bufferWrites bool,
 	db, err := db.OpenDiscovery(instanceKey.Hostname, instanceKey.Port)
 	if err != nil {
 		latency.Stop("instance")
+		DeadInstancesFilter.RegisterInstance(instanceKey)
 		goto Cleanup
 	}
 
@@ -391,9 +392,11 @@ func ReadTopologyInstanceBufferable(instanceKey *InstanceKey, bufferWrites bool,
 
 	err = db.Ping()
 	if err != nil {
+		DeadInstancesFilter.RegisterInstance(instanceKey)
 		goto Cleanup
 	}
 	latency.Stop("instance")
+	DeadInstancesFilter.UnregisterInstance(instanceKey)
 
 	if isMaxScale, resolvedHostname, err = instance.checkMaxScale(db, latency); err != nil {
 		// We do not "goto Cleanup" here, although it should be the correct flow.
@@ -2977,6 +2980,7 @@ func ForgetInstance(instanceKey *InstanceKey) error {
 		return log.Errorf("ForgetInstance(): instance %+v not found", *instanceKey)
 	}
 	AuditOperation("forget", instanceKey, "")
+	DeadInstancesFilter.UnregisterInstance(instanceKey)
 	return nil
 }
 
@@ -2993,6 +2997,7 @@ func ForgetCluster(clusterName string) error {
 	for _, instance := range clusterInstances {
 		forgetInstanceKeys.Set(instance.Key.StringCode(), true, cache.DefaultExpiration)
 		AuditOperation("forget", &instance.Key, "")
+		DeadInstancesFilter.UnregisterInstance(&instance.Key)
 	}
 	_, err = db.ExecOrchestrator(`
 			delete

--- a/go/logic/orchestrator.go
+++ b/go/logic/orchestrator.go
@@ -35,7 +35,7 @@ import (
 	"github.com/openark/orchestrator/go/kv"
 	ometrics "github.com/openark/orchestrator/go/metrics"
 	"github.com/openark/orchestrator/go/process"
-	"github.com/openark/orchestrator/go/raft"
+	orcraft "github.com/openark/orchestrator/go/raft"
 	"github.com/openark/orchestrator/go/util"
 	"github.com/patrickmn/go-cache"
 	"github.com/rcrowley/go-metrics"
@@ -52,6 +52,7 @@ const (
 // that were requested for discovery.  It can be continuously updated
 // as discovery process progresses.
 var discoveryQueue *discovery.Queue
+var deadInstancesDiscoveryQueue *discovery.Queue
 var snapshotDiscoveryKeys chan inst.InstanceKey
 var snapshotDiscoveryKeysMutex sync.Mutex
 
@@ -65,6 +66,8 @@ var isHealthyGauge = metrics.NewGauge()
 var isRaftHealthyGauge = metrics.NewGauge()
 var isRaftLeaderGauge = metrics.NewGauge()
 var discoveryMetrics = collection.CreateOrReturnCollection(discoveryMetricsName)
+
+var deadInstancesDiscoveryQueueLengthGauge = metrics.NewGauge()
 
 var isElectedNode int64 = 0
 
@@ -180,6 +183,38 @@ func handleDiscoveryRequests() {
 			}
 		}()
 	}
+
+	if config.Config.DeadInstanceDiscoveryMaxConcurrency > 0 {
+		deadInstancesDiscoveryQueue = discovery.CreateOrReturnQueue("DEADINSTANCES")
+
+		// Register dead instances queue gauge only if the queue exists
+		metrics.Register("discoveries.dead_instances_queue_length", deadInstancesDiscoveryQueueLengthGauge)
+		ometrics.OnMetricsTick(func() {
+			deadInstancesDiscoveryQueueLengthGauge.Update(int64(deadInstancesDiscoveryQueue.QueueLen()))
+		})
+
+		// create a pool of discovery workers
+		for i := uint(0); i < config.Config.DeadInstanceDiscoveryMaxConcurrency; i++ {
+			go func() {
+				for {
+					instanceKey := deadInstancesDiscoveryQueue.Consume()
+					// Possibly this used to be the elected node, but has
+					// been demoted, while still the queue is full.
+					if !IsLeaderOrActive() {
+						log.Debugf("Node apparently demoted. Skipping discovery of %+v. "+
+							"Remaining queue size: %+v", instanceKey, deadInstancesDiscoveryQueue.QueueLen())
+						deadInstancesDiscoveryQueue.Release(instanceKey)
+						continue
+					}
+
+					DiscoverInstance(instanceKey)
+					deadInstancesDiscoveryQueue.Release(instanceKey)
+				}
+			}()
+		}
+	} else {
+		deadInstancesDiscoveryQueue = discoveryQueue
+	}
 }
 
 // DiscoverInstance will attempt to discover (poll) an instance (unless
@@ -288,14 +323,33 @@ func DiscoverInstance(instanceKey inst.InstanceKey) {
 			continue
 		}
 
-		if replicaKey.IsValid() {
+		if !replicaKey.IsValid() {
+			continue
+		}
+
+		dead, recheck := inst.DeadInstancesFilter.InstanceRecheckNeeded(&replicaKey)
+		if dead {
+			if recheck {
+				deadInstancesDiscoveryQueue.Push(replicaKey)
+			}
+			// dead, but not recheck time
+			continue
+		} else {
 			discoveryQueue.Push(replicaKey)
 		}
 	}
 	// Investigate master:
 	if instance.MasterKey.IsValid() {
 		if !inst.FiltersMatchInstanceKey(&instance.MasterKey, config.Config.DiscoveryIgnoreMasterHostnameFilters) {
-			discoveryQueue.Push(instance.MasterKey)
+			dead, recheck := inst.DeadInstancesFilter.InstanceRecheckNeeded(&instance.MasterKey)
+
+			if dead {
+				if recheck {
+					deadInstancesDiscoveryQueue.Push(instance.MasterKey)
+				}
+			} else {
+				discoveryQueue.Push(instance.MasterKey)
+			}
 		}
 	}
 }
@@ -365,7 +419,19 @@ func onHealthTick() {
 	if len(instanceKeys) > 0 {
 		for _, instanceKey := range instanceKeys {
 			if instanceKey.IsValid() {
-				discoveryQueue.Push(instanceKey)
+				dead, recheck := inst.DeadInstancesFilter.InstanceRecheckNeeded(&instanceKey)
+				if dead {
+					if recheck {
+						// this is a dead instance that needs recheck
+						deadInstancesDiscoveryQueue.Push(instanceKey)
+					}
+					// If the instance is dead, but it is not a time to recheck it
+					// it will be filtered out here.
+					continue
+				} else {
+					// this is a healthy instance that needs recheck
+					discoveryQueue.Push(instanceKey)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/DISTMYSQL-418

Problem:
When there is a lot of inaccessible or unhealthy instances,
the Orchestrator may lose the proper view of the cluster and be late
with needed recovery actions. This is because discoveries of such
instances may take a long time and finish with failure anyway, at the
same time consuming workers from the discovery workers pool.
Healthy instances wait in the queue and they are not checked in a timely
manner.

Solution:
Introduced optional separate discovery queue for unhealthy instances.
This queue is serviced by the separate pool of discovery workers.

Introduced optional exponential backoff mechanism for unhealthy
instances discovery.

Introduced two API endpoints
discovery-queue-metrics-raw/:queue/:seconds
discovery-queue-metrics-raw/:queue/:seconds
where :queue parameter can be DEFAULT or DEADINSTANCES

Introduced new gauge
discoveries.dead_instances_queue_length

Documentation updated.

Configuration variables:
DeadInstanceDiscoveryMaxConcurrency
DeadInstancePollSecondsMultiplyFactor
DeadInstancePollSecondsMax
DeadInstanceDiscoveryLogsEnabled