### PR TITLE
Fix: downtime registration without duration now sets default value and updated docs too

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -94,6 +94,8 @@ Shown above are uses for both `orchestrator-client` and the `orchestrator` comma
 ```shell
 $ curl -s "http://my.orchestrator.service:80/api/begin-downtime/my.hostname/3306/wallace/experimenting+failover/45m"
 ```
+`45m` is duration of time in minutes the host will be marked under downtime.
+If we don't mention the time, it would consider `config.MaintenanceExpireMinutes` time as downtime which is default 10m
 
 The `orchestrator-client` script runs this very API call, wrapping it up and encoding the URL path. It can also automatically detect the leader, in case you don't want to run through a proxy.
 

--- a/go/inst/downtime.go
+++ b/go/inst/downtime.go
@@ -18,7 +18,9 @@ package inst
 
 import (
 	"time"
+	"github.com/openark/orchestrator/go/config"
 )
+
 
 type Downtime struct {
 	Key            *InstanceKey
@@ -32,6 +34,9 @@ type Downtime struct {
 }
 
 func NewDowntime(instanceKey *InstanceKey, owner string, reason string, duration time.Duration) *Downtime {
+	if duration == 0 {
+		duration = config.MaintenanceExpireMinutes * time.Minute
+	}	
 	downtime := &Downtime{
 		Key:      instanceKey,
 		Owner:    owner,


### PR DESCRIPTION
Adding a downtime with API without a duration didn't add the downtime.
So the changes will allow to set default duration when the duration is not passed specifically using the configuration parameter in orchestrator `MaintenanceExpireMinutes`.

<!--
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR
-->

Related issue: https://github.com/openark/orchestrator/issues/0123456789


### Description

This PR [briefly explain what is does]

<!--
Please make sure that:

- [ ] contributed code is using same conventions as original code

Please make sure the PR passes CI tests. For your information, CI tests the following:

- code is formatted via `gofmt` (please avoid `goimports`)
- code passes compilation
- code passes unit tests
- code passes integration tests with MySQL backend
- code passes integration tests with SQLite backend
- There are no orphaned docs/ pages (there's some link in the docs to point to any page)
- upgrade from previous version (`master` branch) is successful
 -->
