### PR TITLE
Fix: Tag deletion not propagated to all Raft peers, causing data inconsistency

### DIFF
--- a/go/http/api.go
+++ b/go/http/api.go
@@ -1999,6 +1999,9 @@ func (this *HttpAPI) Untag(params martini.Params, r render.Render, req *http.Req
 		return
 	}
 	untagged, err := inst.Untag(&instanceKey, tag)
+	if orcraft.IsRaftEnabled() {
+		_, err = orcraft.PublishCommand("delete-instance-tag", inst.InstanceTag{Key: instanceKey, T: *tag})
+	}
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
 		return
@@ -2015,6 +2018,9 @@ func (this *HttpAPI) UntagAll(params martini.Params, r render.Render, req *http.
 		return
 	}
 	untagged, err := inst.Untag(nil, tag)
+	if orcraft.IsRaftEnabled() {
+		_, err = orcraft.PublishCommand("delete-instance-tag", inst.InstanceTag{Key: inst.InstanceKey{}, T: *tag})
+	}
 	if err != nil {
 		Respond(r, &APIResponse{Code: ERROR, Message: err.Error()})
 		return

--- a/go/logic/command_applier.go
+++ b/go/logic/command_applier.go
@@ -278,6 +278,10 @@ func (applier *CommandApplier) deleteInstanceTag(value []byte) interface{} {
 	if err := json.Unmarshal(value, &instanceTag); err != nil {
 		return log.Errore(err)
 	}
+	if (instanceTag.Key == inst.InstanceKey{}) {
+		_, err := inst.Untag(nil, &instanceTag.T)
+		return err
+	}
 	_, err := inst.Untag(&instanceTag.Key, &instanceTag.T)
 	return err
 }


### PR DESCRIPTION


<!--
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR
-->

Related issue: https://github.com/percona/orchestrator/issues/76 


### Description

This PR ensures that tag deletions are propagated to all Raft peers, similar to how tag additions are currently handled.

**Problem**:
When deleting a tag (Untag) or removing all tags (UntagAll), the change was only applied locally and not published to other Raft nodes. This caused tag data inconsistencies across the cluster.

**Fix**:
Added calls to the existing Raft command applier logic in both Untag and UntagAll methods so that deletions are broadcast to all peers.
This aligns tag deletion behavior with tag addition behavior.

**Notes**:
No changes to API responses.
The fix only affects internal Raft state propagation, ensuring consistency across nodes.

<!--
Please make sure that:

- [ ] contributed code is using same conventions as original code

Please make sure the PR passes CI tests. For your information, CI tests the following:

- code is formatted via `gofmt` (please avoid `goimports`)
- code passes compilation
- code passes unit tests
- code passes integration tests with MySQL backend
- code passes integration tests with SQLite backend
- There are no orphaned docs/ pages (there's some link in the docs to point to any page)
- upgrade from previous version (`master` branch) is successful
 -->
