### PR TITLE
DISTMYSQL-327: orchestrator semi-sync configuration indication in GUI…

### DIFF
--- a/resources/public/js/orchestrator.js
+++ b/resources/public/js/orchestrator.js
@@ -371,8 +371,18 @@ function openNodeModal(node) {
       $('#node_modal [data-btn-group=gtid-errant-fix]').show();
     }
   }
-  addNodeModalDataAttribute("Semi-sync enforced", booleanString(node.SemiSyncEnforced));
-
+  addNodeModalDataAttribute("Semi-sync source enabled", booleanString(node.SemiSyncMasterEnabled));
+  if (node.SemiSyncMasterEnabled) {
+    addNodeModalDataAttribute("Is semi-sync source", node.SemiSyncMasterStatus);
+  }
+  addNodeModalDataAttribute("Semi-sync replica enabled", booleanString(node.SemiSyncReplicaEnabled));
+  if (node.SemiSyncReplicaEnabled) {
+    addNodeModalDataAttribute("Is semi-sync replica", node.SemiSyncReplicaStatus);
+    addNodeModalDataAttribute("Enforce semi-sync on replicas after failover", booleanString(node.SemiSyncPriority > 0));
+    if (node.SemiSyncPriority > 0) {
+      addNodeModalDataAttribute("Enforce semi-sync on replicas after failover priority", node.SemiSyncPriority);
+    }
+  }
   addNodeModalDataAttribute("Uptime", node.Uptime);
   addNodeModalDataAttribute("Allow TLS", node.AllowTLS);
   addNodeModalDataAttribute("Region", node.Region);


### PR DESCRIPTION
… is wrong/misleading

https://perconadev.atlassian.net/browse/DISTMYSQL-327

Problem:
There is misleading information 'Semi-sync enforced" in node's detailed view

Cause:
Commit 1a6c3cd6 exchanged Instance.SemiSyncEnforced member with Instance.SemiSyncPriority and modified logic around enforcing semi-sync mode on replicas after failover. Now only master's expected count of semi-sync replicas will be switched to semi-sync according to the priority.
Because of member name change, SemiSyncEnforced was not present in JavaScript world, so in node's detailed view it was always visible 'Semi-sync enforced: false'. In other words - it didn't work. Moreover 'Semi-sync enforced' label was confusing.

Solution:
1. Changed 'Semi-sync enforced' to 'Enforce semi-sync on replicas after failover' (true if SemiSyncPriority>0)
2. If SemiSyncPriority > 0, display 'Enforce semi-sync on replicas after failover priority'
3. Display 'Semi-sync source enabled' and 'Semi-sync replica enabled'
4. If 'Semi-sync source enabled' display 'Is semi-sync source' which reflects 'Rpl_semi_sync_source_status'
5. If 'Semi-sync replica enabled' display 'Is semi-sync replica' which reflects 'Rpl_semi_sync_replica_status'. 1 and 2 information is also displayed only if 'Semi-sync replica enabled: true'

<!--
## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.
Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR
-->

Related issue: https://github.com/openark/orchestrator/issues/0123456789


### Description

This PR [briefly explain what is does]

<!--
Please make sure that:

- [ ] contributed code is using same conventions as original code

Please make sure the PR passes CI tests. For your information, CI tests the following:

- code is formatted via `gofmt` (please avoid `goimports`)
- code passes compilation
- code passes unit tests
- code passes integration tests with MySQL backend
- code passes integration tests with SQLite backend
- There are no orphaned docs/ pages (there's some link in the docs to point to any page)
- upgrade from previous version (`master` branch) is successful
 -->
