### PR TITLE
fix: prevent panic on non-MySQL errors in PopulateGroupReplicationInformation

### DIFF
--- a/go/inst/instance_dao.go
+++ b/go/inst/instance_dao.go
@@ -3468,15 +3468,14 @@ func PopulateGroupReplicationInformation(instance *Instance, db *sql.DB) error {
 	`
 	rows, err := db.Query(q)
 	if err != nil {
-		_, grNotSupported := GroupReplicationNotSupportedErrors[err.(*mysql.MySQLError).Number]
-		if grNotSupported {
-			return nil // If GR is not supported by the instance, just exit
-		} else {
-			// If we got here, the query failed but not because the server does not support group replication. Let's
-			// log the error
-			return log.Errorf("There was an error trying to check group replication information for instance "+
-				"%+v: %+v", instance.Key, err)
+		var mysqlErr *mysql.MySQLError
+		if errors.As(err, &mysqlErr) {
+			if _, ok := GroupReplicationNotSupportedErrors[mysqlErr.Number]; ok {
+				return nil // If GR is not supported by the instance, just exit
+			}
 		}
+		return log.Errorf("There was an error trying to check group replication information for instance "+
+			"%+v: %+v", instance.Key, err)
 	}
 	defer rows.Close()
 	foundGroupPrimary := false


### PR DESCRIPTION
## Problem

`PopulateGroupReplicationInformation` uses an unsafe type assertion that crashes the orchestrator on any non-MySQL error:

```go
_, grNotSupported := GroupReplicationNotSupportedErrors[err.(*mysql.MySQLError).Number]
```

When `db.Query` returns a non-`*mysql.MySQLError` error — such as a **network timeout, connection refused, DNS failure, or context cancellation** — the direct type assertion panics, crashing the orchestrator process.

## Impact

- **Severity**: Crash (panic) in the core instance discovery/monitoring loop
- **Trigger**: Any transient network issue to a MySQL instance that has Group Replication enabled
- **Frequency**: Easily triggered in production environments with network instability
- **Affected function**: `PopulateGroupReplicationInformation` in `go/inst/instance_dao.go`
- **Call path**: Called during every instance poll cycle for Group Replication topology members

## Root Cause

The code assumes all errors from `db.Query` are `*mysql.MySQLError`. This is only true for errors returned by the MySQL server itself. Network-layer errors, driver errors, and wrapped errors are not `*mysql.MySQLError` and cause the assertion to panic.

## Fix

Replace the unsafe type assertion with `errors.As()`, which:
1. **Does not panic** on non-matching error types
2. **Handles wrapped errors** (e.g., `fmt.Errorf("query failed: %w", mysqlErr)`)
3. **Is the Go 1.13+ idiom** for error type checking

```go
var mysqlErr *mysql.MySQLError
if errors.As(err, &mysqlErr) {
    if _, ok := GroupReplicationNotSupportedErrors[mysqlErr.Number]; ok {
        return nil
    }
}
return log.Errorf(...)
```

## Testing

- `go build ./go/inst/` compiles successfully
- No other instances of `err.(*mysql.MySQLError)` without comma-ok exist in the codebase

## Checklist

- [x] Fix is minimal and only addresses the unsafe type assertion
- [x] No business logic changes
- [x] Uses standard library `errors` package (already imported)
- [x] Compiles without errors